### PR TITLE
Fixes range on some ability cards

### DIFF
--- a/frosthaven_assistant/assets/data/editions/Forgotten Circles.json
+++ b/frosthaven_assistant/assets/data/editions/Forgotten Circles.json
@@ -95,8 +95,8 @@
         [ 995, false, 37, "%move% - 1","*.........", "%attack% + 0", "^%range% + 1", "^%immobilize%" ],
         [ 996, false, 48, "^£ELITE:", "!^Focus on the enemy","^with the lowest current hit point value.", "%move% + 1","*.........", "%attack% + 0", "^%range% + 0" ],
         [ 997, false, 55, "^£ELITE:", "!^Focus on the enemy","^with the highest current hit point value.",
-          "%move% + 0","*.........", "%attack% - 1", "^%wound%"],
-        [ 998, true, 69, "%attack% + 1","*.........", "%heal% 1", "*.........","%regenerate%", "^Self" ]
+          "%move% + 0","*.........", "%attack% - 1", "^%range% + 0", "^%wound%"],
+        [ 998, true, 69, "%attack% + 1", "^%range% + 0","*.........", "%heal% 1", "*.........","%regenerate%", "^Self" ]
       ]
     },
     {

--- a/frosthaven_assistant/assets/data/editions/Gloomhaven.json
+++ b/frosthaven_assistant/assets/data/editions/Gloomhaven.json
@@ -748,7 +748,7 @@
           "x": 0.783,
           "y": 0.76
         }], "     %attack% + 0", "^%range% + 0", "[r]","%ice%%use%", "^+2 %attack%", "!^%immobilize%", "[/r]","*.........", "%retaliate% + 2" ],
-        [ 713, false, 14, "%shield% + 4","*.........", "%heal% 2", "^%range% 3","[r]", "%ice%%use%", "^+3 %heal%", "[/r]","*.........", "[r]","%air%%use%", "^%attack% + 0", "[/r]" ],
+        [ 713, false, 14, "%shield% + 4","*.........", "%heal% 2", "^%range% 3","[r]", "%ice%%use%", "^+3 %heal%", "[/r]","*.........", "[r]","%air%%use%", "^%attack% + 0", "^%range% + 0", "[/r]" ],
         [ 714, true, 47, [{
           "gfx": "air",
           "x": 0.783,

--- a/frosthaven_assistant/assets/data/editions/JotL.json
+++ b/frosthaven_assistant/assets/data/editions/JotL.json
@@ -88,9 +88,9 @@
       "name": "Basic Vermling Raider",
       "note": "initial test for ..... lines",
       "cards": [
-        ["Screaming Shot", 368, true, 85, "%push% 1", "^Target all adjacent enemies", "*.........", "%attack% + 1", "^%range% + 2", "*Shuffle this deck at the end of the round." ],
-        ["Careful Throw", 369, false, 36, "%move% + 0","*.........", "%attack% - 1", "^%range% + 2", "*They will move to avoid being adjacent to their focus." ],
-        ["Dual Daggers", 370, false, 59, "%attack% + 0", "^%range% + 2", "^%target% 2", "*They are not moving this round." ],
+        ["Screaming Shot", 368, true, 85, "%push% 1", "^Target all adjacent enemies", "*.........", "%attack% + 1", "^%range% 2", "*Shuffle this deck at the end of the round." ],
+        ["Careful Throw", 369, false, 36, "%move% + 0","*.........", "%attack% - 1", "^%range% 2", "*They will move to avoid being adjacent to their focus." ],
+        ["Dual Daggers", 370, false, 59, "%attack% + 0", "^%range% 2", "^%target% 2", "*They are not moving this round." ],
         ["Nothing Special", 371, false, 50, "%move% + 0","*.........", "%attack% + 0", "*This is exactly how they acted last scenario." ]
       ]
     },


### PR DESCRIPTION
This adds `range + 0` to 2 ability cards in Tracker deck in FC and one Savvas Icestorm ability card in GH. Personally, I would prefer if there was no `range + 0` in any card, as in the physical game; if some cards have it, though, they all should (as it can be confusing, looking like a melee attack).

It also fixes the range on Basic Vermling Raider for JotL from `range + 2` to `range 2`.