### PR TITLE
Enforce both lower and upper bounds when adjusting monster levels

### DIFF
--- a/frosthaven_assistant/lib/Resource/commands/set_scenario_command.dart
+++ b/frosthaven_assistant/lib/Resource/commands/set_scenario_command.dart
@@ -135,7 +135,7 @@ class SetScenarioCommand extends Command {
           isAlly = true;
         }
         _gameState.currentList.add(GameMethods.createMonster(
-            monster, min(_gameState.level.value + levelAdjust, 7), isAlly)!);
+            monster, (_gameState.level.value + levelAdjust).clamp(0, 7), isAlly)!);
       }
     }
 

--- a/frosthaven_assistant/lib/Resource/game_methods.dart
+++ b/frosthaven_assistant/lib/Resource/game_methods.dart
@@ -697,7 +697,7 @@ class GameMethods {
           Monster? monster = _gameState.currentList.firstWhereOrNull((element) => element.id == rule.name) as Monster?;
           if(monster != null) {
             if(_gameState.level.value == monster.level.value) {
-              int newLevel = min(7,monster.level.value + rule.level);
+              int newLevel = (monster.level.value + rule.level).clamp(0, 7);
               monster.level.value = newLevel;
               for(MonsterInstance instance in monster.monsterInstances.value) {
                 instance.setLevel(monster);


### PR DESCRIPTION
When a scenario's special rules include monster level adjustments, the app was enforcing an upper bound of 7 but not a lower bound of 0.  You can reproduce the issue by starting Crimson Scales scenario 62 at Scenario Level 0.  The Aesther Ashblade has a LevelAdjust value of -1, and so the scenario doesn't allow you to add that monster instead of adding it at level 0.  

I replaced the two instances of the `min` function with a `clamp` function to try to address this.  Note that I haven't tested this code since I'm new to Flutter apps, so feel free to edit the PR if necessary.  And thanks for all your work on this app!