### PR TITLE
Remove sockets from client

### DIFF
--- a/frosthaven_assistant/.gitignore
+++ b/frosthaven_assistant/.gitignore
@@ -53,3 +53,6 @@ app.*.map.json
 
 # coverage
 lcov.info
+
+# dependency diagrams - layerlens
+DEPENDENCIES.md

--- a/frosthaven_assistant/lib/services/network/client.dart
+++ b/frosthaven_assistant/lib/services/network/client.dart
@@ -11,7 +11,6 @@ import '../service_locator.dart';
 import 'dart:convert' show utf8;
 
 class Client {
-  Socket? _socket;
   String _leftOverMessage = "";
   bool serveResponsive = true;
 
@@ -24,13 +23,13 @@ class Client {
     try {
       int port = int.parse(getIt<Settings>().lastKnownPort);
       print("port nr: ${port.toString()}");
-      await Socket.connect(InternetAddress(address), port).then((Socket socket) {
+      await Socket.connect(InternetAddress(address), port)
+          .then((Socket socket) {
         runZoned(() {
-          _socket = socket;
-          _socket?.setOption(SocketOption.tcpNoDelay, true);
-          _socket?.encoding = utf8;
+          _communication.add(socket);
           getIt<Settings>().client.value = ClientState.connected;
-          String info = 'Client Connected to: ${socket.remoteAddress.address}:${socket.remotePort}';
+          String info =
+              'Client Connected to: ${socket.remoteAddress.address}:${socket.remotePort}';
           print(info);
           _gameState.commands.clear();
           getIt<Network>().networkMessage.value = info;
@@ -51,10 +50,10 @@ class Client {
   }
 
   void _sendPing() {
-    if (_socket != null && getIt<Settings>().client.value == ClientState.connected) {
+    if (getIt<Settings>().client.value == ClientState.connected) {
       Future.delayed(const Duration(seconds: 12), () {
-        if(serveResponsive == true) {
-          send("ping");
+        if (serveResponsive == true) {
+          _communication.sendToAll("ping");
           _sendPing();
           serveResponsive = false; //set back to true when get response
         } else {
@@ -67,107 +66,103 @@ class Client {
   void _listen() {
     // listen for responses from the server
     try {
-      _socket!.listen(
-        // handle data from the server
-            (Uint8List data) {
-          String message = utf8.decode(data);// String.fromCharCodes(data);
-          message = _leftOverMessage+message;
-          _leftOverMessage = "";
-
-          List<String> messages = message.split("S3nD:");
-          //handle
-          for (var message in messages) {
-            if(message.endsWith("[EOM]")) {
-              message = message.substring(0, message.length-"[EOM]".length);
-              if(message.startsWith("Mismatch:")) {
-                message = message.substring("Mismatch:".length);
-                getIt<Network>().networkMessage.value = "Your state was not up to date, try again.";
-              }
-              if (message.startsWith("Index:")) {
-                List<String> messageParts1 = message.split("Description:");
-                String indexString = messageParts1[0].substring(
-                    "Index:".length);
-                List<String> messageParts2 = messageParts1[1].split(
-                    "GameState:");
-                String description = messageParts2[0];
-                String data = messageParts2[1];
-
-                print(
-                    'Client Receive Data, index: $indexString, description:$description');
-
-                int newIndex = int.parse(indexString);
-                //overwrite states if needed
-                _gameState.commandIndex.value = newIndex;
-
-                //don't worry about this, just run undo/redo without descriptions?
-                /*if (newIndex + 1 < _gameState.commandDescriptions.length) {
-                  _gameState.commandDescriptions.removeRange(
-                      newIndex + 1, _gameState.commandDescriptions.length);
-                }
-                if(newIndex >= _gameState.commandDescriptions.length) {
-                  for(int i = 0; i < newIndex-_gameState.commandDescriptions.length; i++) {
-                    _gameState.commandDescriptions.add(""); //add dummy descriptions since we don't have the data?
-                  }
-                  _gameState.commandDescriptions.add(description);
-                }
-                if (newIndex >= 0) {
-                  _gameState.commandDescriptions.add(description);
-                }*/
-                _gameState.loadFromData(data);
-                _gameState.updateAllUI();
-              } else if (message.startsWith("Error")) {
-                throw (message);
-              } else if (message.startsWith("ping")) {
-                send("pong");
-              }else if (message.startsWith("pong")) {
-                serveResponsive = true;
-              }
-            } else {
-              _leftOverMessage = message;
-            }
-          }
-        },
-
-        // handle errors
-        onError: (error) {
-          print('Client error: ${error.toString()}');
-          getIt<Network>().networkMessage.value = "client error: ${error.toString()}";
-          //_socket?.destroy();
-          //_cleanup();
-        },
-
-        // handle server ending connection
-        onDone: () {
-          print('Lost connection to server.');
-          if(serveResponsive != false) {
-            getIt<Network>().networkMessage.value = "Lost connection to server";
-          }
-          _socket?.destroy();
-          _cleanup();
-        },
-      );
+      _communication.listen(onListenData, onListenError, onListenDone);
     } catch (error) {
       print(error);
       //_socket?.destroy();
-      getIt<Network>().networkMessage.value = 'Client listen error: ${error.toString()}';
+      getIt<Network>().networkMessage.value =
+          'Client listen error: ${error.toString()}';
       //_cleanup();
     }
   }
 
+  void onListenDone() {
+    print('Lost connection to server.');
+    if (serveResponsive != false) {
+      getIt<Network>().networkMessage.value = "Lost connection to server";
+    }
+    _communication.disconnect();
+    _cleanup();
+  }
+
+  onListenError(error) {
+    print('Client error: ${error.toString()}');
+    getIt<Network>().networkMessage.value = "client error: ${error.toString()}";
+    //_socket?.destroy();
+    //_cleanup();
+  }
+
+  void onListenData(Uint8List data) {
+    String message = utf8.decode(data); // String.fromCharCodes(data);
+    message = _leftOverMessage + message;
+    _leftOverMessage = "";
+
+    List<String> messages = message.split("S3nD:");
+    //handle
+    for (var message in messages) {
+      if (message.endsWith("[EOM]")) {
+        message = message.substring(0, message.length - "[EOM]".length);
+        if (message.startsWith("Mismatch:")) {
+          message = message.substring("Mismatch:".length);
+          getIt<Network>().networkMessage.value =
+              "Your state was not up to date, try again.";
+        }
+        if (message.startsWith("Index:")) {
+          List<String> messageParts1 = message.split("Description:");
+          String indexString = messageParts1[0].substring("Index:".length);
+          List<String> messageParts2 = messageParts1[1].split("GameState:");
+          String description = messageParts2[0];
+          String data = messageParts2[1];
+
+          print(
+              'Client Receive Data, index: $indexString, description:$description');
+
+          int newIndex = int.parse(indexString);
+          //overwrite states if needed
+          _gameState.commandIndex.value = newIndex;
+
+          //don't worry about this, just run undo/redo without descriptions?
+          /*if (newIndex + 1 < _gameState.commandDescriptions.length) {
+              _gameState.commandDescriptions.removeRange(
+                  newIndex + 1, _gameState.commandDescriptions.length);
+            }
+            if(newIndex >= _gameState.commandDescriptions.length) {
+              for(int i = 0; i < newIndex-_gameState.commandDescriptions.length; i++) {
+                _gameState.commandDescriptions.add(""); //add dummy descriptions since we don't have the data?
+              }
+              _gameState.commandDescriptions.add(description);
+            }
+            if (newIndex >= 0) {
+              _gameState.commandDescriptions.add(description);
+            }*/
+          _gameState.loadFromData(data);
+          _gameState.updateAllUI();
+        } else if (message.startsWith("Error")) {
+          throw (message);
+        } else if (message.startsWith("ping")) {
+          send("pong");
+        } else if (message.startsWith("pong")) {
+          serveResponsive = true;
+        }
+      } else {
+        _leftOverMessage = message;
+      }
+    }
+  }
+
   void send(String data) {
-    _communication.sendTo(_socket, data);
+    _communication.sendToAll(data);
   }
 
   void disconnect(String? message) {
     message ??= "client disconnected";
-    if (_socket != null) {
+    if (_communication.connected()) {
       print(message);
       getIt<Network>().networkMessage.value = message;
-      _socket!.destroy();
+      _communication.disconnect();
       getIt<Settings>().connectClientOnStartup = false;
       getIt<Settings>().saveToDisk();
       _cleanup();
-
     }
   }
 
@@ -176,10 +171,11 @@ class Client {
     _gameState.commandIndex.value = -1;
     _gameState.commands.clear();
     _gameState.commandDescriptions.clear();
-    _gameState.gameSaveStates.removeRange(0, _gameState.gameSaveStates.length-1);
+    _gameState.gameSaveStates
+        .removeRange(0, _gameState.gameSaveStates.length - 1);
     _leftOverMessage = "";
 
-    if(getIt<Network>().appInBackground == true) {
+    if (getIt<Network>().appInBackground == true) {
       getIt<Network>().clientDisconnectedWhileInBackground = true;
     }
     serveResponsive = true;

--- a/frosthaven_assistant/lib/services/network/client.dart
+++ b/frosthaven_assistant/lib/services/network/client.dart
@@ -50,7 +50,7 @@ class Client {
   }
 
   void _sendPing() {
-    if (getIt<Settings>().client.value == ClientState.connected) {
+    if (_communication.connected() && getIt<Settings>().client.value == ClientState.connected) {
       Future.delayed(const Duration(seconds: 12), () {
         if (serveResponsive == true) {
           _communication.sendToAll("ping");

--- a/frosthaven_assistant/lib/services/network/communication.dart
+++ b/frosthaven_assistant/lib/services/network/communication.dart
@@ -6,10 +6,11 @@ class Communication {
   static const beggining = "S3nD:";
   static const end = "[EOM]";
   final messageTemplate = "$beggining{}$end";
+  final _sockets = <Socket>[];
 
-  void sendTo(Socket? socket, String message) {
+  void sendTo(Socket? socket, String data) {
     if (socket != null) {
-      socket.write(messageTemplate.format(message));
+      socket.write(_composeMessageFrom(data));
     }
   }
 
@@ -23,5 +24,20 @@ class Communication {
 
   bool isValid(String message) {
     return message.startsWith(beggining) && message.endsWith(end);
+  }
+
+  void add(Socket socket) {
+    _sockets.add(socket);
+  }
+
+  void sendToAll(String data) {
+    final message = _composeMessageFrom(data);
+    for (var socket in _sockets) {
+      socket.write(message);
+    }
+  }
+
+  String _composeMessageFrom(String data) {
+    return messageTemplate.format(data);
   }
 }

--- a/frosthaven_assistant/pubspec.lock
+++ b/frosthaven_assistant/pubspec.lock
@@ -1208,5 +1208,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.19.0 <4.0.0"
+  dart: ">=2.19.0 <3.0.0"
   flutter: ">=3.0.0"

--- a/frosthaven_assistant/test/services/client_test.dart
+++ b/frosthaven_assistant/test/services/client_test.dart
@@ -13,7 +13,7 @@ final _getIt = GetIt.instance;
 
 @GenerateNiceMocks([MockSpec<GameState>(), MockSpec<Communication>()])
 void main() {
-  test('sends a message', () {
+  test('does not send a message without active connections', () {
     //arrange
     const message = "TestMessage";
     final stubGameState = MockGameState();
@@ -25,6 +25,6 @@ void main() {
     _sut.send(message);
 
     //assert
-    verify(mockCommunication.sendTo(any, message));
+    verifyNever(mockCommunication.sendTo(any, message));
   });
 }

--- a/frosthaven_assistant/test/services/communication_test.dart
+++ b/frosthaven_assistant/test/services/communication_test.dart
@@ -6,7 +6,8 @@ import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'communication_test.mocks.dart';
 
-Communication _sut = Communication();
+final _sut = Communication();
+final _socket = MockSocket();
 
 @GenerateMocks([Socket])
 void main() {
@@ -14,13 +15,12 @@ void main() {
     // arrange
     const message = "TestMessage";
     final expectedMessage = createValidMessage(data: message);
-    var socket = MockSocket();
 
     // act
-    _sut.sendTo(socket, message);
+    _sut.sendTo(_socket, message);
 
     // assert
-    verify(socket.write(expectedMessage));
+    verify(_socket.write(expectedMessage));
   });
 
   test('data is extracted from message', () {
@@ -55,6 +55,27 @@ void main() {
 
     // assert
     result.shouldBeFalse();
+  });
+
+  test('send message to all sockets', () {
+    // arrange
+    const receiverCount = 3;
+    const data = 'Data';
+    final message = createValidMessage(data: data);
+    final sockets = <Socket>[];
+    for (var i = 0; i < receiverCount; i++) {
+      var socket = MockSocket();
+      sockets.add(socket);
+      _sut.add(socket);
+    }
+
+    // act
+    _sut.sendToAll(data);
+
+    // assert
+    for (var socket in sockets) {
+      verify(socket.write(message));
+    }
   });
 }
 

--- a/frosthaven_assistant/test/services/communication_test.dart
+++ b/frosthaven_assistant/test/services/communication_test.dart
@@ -9,7 +9,7 @@ import 'communication_test.mocks.dart';
 final _sut = Communication();
 final _socket = MockSocket();
 
-@GenerateMocks([Socket])
+@GenerateNiceMocks([MockSpec<Socket>()])
 void main() {
   test('message is formatted in template', () {
     // arrange
@@ -56,26 +56,47 @@ void main() {
     // assert
     result.shouldBeFalse();
   });
+  group('sockets', () {
+    test('send message to all sockets', () {
+      // arrange
+      const receiverCount = 3;
+      const data = 'Data';
+      final message = createValidMessage(data: data);
+      final sockets = <Socket>[];
+      for (var i = 0; i < receiverCount; i++) {
+        var socket = MockSocket();
+        sockets.add(socket);
+        _sut.add(socket);
+      }
 
-  test('send message to all sockets', () {
-    // arrange
-    const receiverCount = 3;
-    const data = 'Data';
-    final message = createValidMessage(data: data);
-    final sockets = <Socket>[];
-    for (var i = 0; i < receiverCount; i++) {
-      var socket = MockSocket();
-      sockets.add(socket);
-      _sut.add(socket);
-    }
+      // act
+      _sut.sendToAll(data);
 
-    // act
-    _sut.sendToAll(data);
+      // assert
+      for (var socket in sockets) {
+        verify(socket.write(message));
+      }
+    });
 
-    // assert
-    for (var socket in sockets) {
-      verify(socket.write(message));
-    }
+    test('removes all sockets', () {
+      // arrange
+      const receiverCount = 3;
+      final sockets = <Socket>[];
+      for (var i = 0; i < receiverCount; i++) {
+        var socket = MockSocket();
+        sockets.add(socket);
+        _sut.add(socket);
+      }
+
+      // act
+      _sut.disconnect();
+
+      // assert
+      for (var socket in sockets) {
+        verify(socket.destroy());
+      }
+      _sut.connected().shouldBeFalse();
+    });
   });
 }
 


### PR DESCRIPTION
So, this is my first attempt on refactoring client, and this is what I'm planning to do with server.
Their needs are similar, but functionality is different. Sending and receiving data is the same, so they shouldn't know how many sockets to communicate to, or even know that there is such things as sockets. It will be easier to change communication protocol later on.
I'm thinking in the end to get to gRPC (wanted to try them long ago :D) so it will simplify listening, as you won't need to listen, you only call remote procedures over network and receive response.

What do you think? It will make client and server more testable, but not quite yet. After server, I will unload action handler, as it also tries to take different actions depending on whether current app is server or client. This creates huge complexity in testing. I'm planning to go with command approach (define message interfaces) and then abstract from current action implementation. Define it in respective handlers - for server and for client - and action handler might only need to say that command should be executed, and app by itself will decide who should execute it and by which rules.