### PR TITLE
Add tests to communication

### DIFF
--- a/frosthaven_assistant/lib/services/network/communication.dart
+++ b/frosthaven_assistant/lib/services/network/communication.dart
@@ -65,12 +65,11 @@ class Communication {
     if (toDisconnect != null) {
       toDisconnect.destroy();
       _sockets.remove(toDisconnect);
-    } else {
-      print('Could not find socket from connected list: [{}]'
-          .format(_sockets.join('; ')));
     }
   }
 
+  // TODO: Need to test this somehow, or refactor altogether.
+  // If testing, then better to verify assigned functions are being called on specific actions, rather than verify mock socket assignments.
   void listen(
       Function(Uint8List) onData, Function? onError, Function()? onDone) {
     for (var socket in _sockets) {


### PR DESCRIPTION
Simulated socket exception handling in disconnection.
Testing `listen` proved to be difficult, so I might refactor that.
Next time will add de-duplication upon socket addition and tests there. Then will refactor communication, so finally that one will be closed and will remove all network.client and network.server dependencies with communication 😁 
Slowly will remove circular dependencies, as there are many. `getIt` proved to be too convenient 😆 
