### PR TITLE
A few Frosthaven scenario data fixes

### DIFF
--- a/frosthaven_assistant/assets/data/editions/Frosthaven.json
+++ b/frosthaven_assistant/assets/data/editions/Frosthaven.json
@@ -1273,7 +1273,7 @@
       "gfx": "City Guard",
       "hidden": true,
       "deck": "Boss (FH)",
-      "count": 6,
+      "count": 2,
       "levels": [
         {
           "level": 0, "health": "2xC",  "move": 0,  "attack": 4,
@@ -8179,7 +8179,7 @@
       "monsters": [ "Black Imp (FH)", "Burrowing Blade", "Lightning Eel", "Polar Bear" ],
       "lootDeck": {"coin":7,"lumber": 2,"metal":3,"hide": 4,"rockroot":2,"snowthistle":1, "treasure": 1}
     },
-    "#86 Lady in White": {
+    "#86 The Lady in White": {
       "monsters": [ "Black Imp (FH)", "Earth Demon (FH)", "Ice Wraith" ],
       "lootDeck": {"coin":10,"lumber": 4,"hide": 2,"axenut":1,"arrowvine":2, "flamefruit": 1},
       "special": [
@@ -9143,7 +9143,7 @@
       "monsters": [ "Ancient Artillery (FH)", "Frozen Corpse", "Ice Wraith" ],
       "lootDeck": {"coin":5,"lumber": 6,"metal":4,"hide": 4,"treasure": 1}
     },
-    "#128 A Tall Drunken Trail": {
+    "#128 A Tall Drunken Tale": {
       "monsters": [ "Abael Scout", "Lurker wavethrower Scenario 128", "Snow Imp", "Steel Automaton Scenario 128", "Vermling Scout (FH)" ],
       "lootDeck": {"coin":2,"lumber": 3,"metal":1,"hide": 8,"snowthistle":1,"arrowvine":1, "flamefruit": 2},
       "special": [
@@ -9232,7 +9232,7 @@
         }
       }
     },
-    "#130 And Then, A Stream": {
+    "#130 And Then, a Stream": {
       "monsters": [ "Frozen Corpse", "Lightning Eel", "Shrike Fiend" ],
       "lootDeck": {"coin":6,"lumber": 5,"metal":2,"hide": 3,"flamefruit":1,"arrowvine":2, "treasure": 1},
       "special": [
@@ -9347,7 +9347,7 @@
       "monsters": [ "Lightning Eel", "Living Bones (FH)", "Living Spirit (FH)", "Lurker Wavethrower", "Piranha Pig" ],
       "lootDeck": {"coin":8,"lumber": 4,"hide": 4,"snowthistle":1,"arrowvine":1}
     },
-    "#137 The Pirate Queen's Haul": {
+    "#137 Pirate Queen's Haul": {
       "monsters": [ "Ancient Artillery (FH)", "Flaming Bladespinner", "Forest Imp (FH)", "Piranha Pig", "Polar Bear" ,"Robotic Boltshooter" ],
       "lootDeck": {"coin":12,"lumber": 4,"metal":4,"hide": 4,"treasure": 1}
     }


### PR DESCRIPTION
- Limiting the number of Brothers to 2, so that they are always Brother 1 and Brother 2.
- Fixing the title of a few scenarios which are a little bit off from the scenario book.