### PR TITLE
Add Host resolution and improve network adapter resolution for desktop

### DIFF
--- a/frosthaven_assistant/lib/services/network/client.dart
+++ b/frosthaven_assistant/lib/services/network/client.dart
@@ -26,7 +26,13 @@ class Client {
     try {
       int port = int.parse(_settings.lastKnownPort);
       debugPrint("port nr: ${port.toString()}");
-      await _connection.connect(InternetAddress(address), port)
+      List<InternetAddress> resolvedAddress =
+          await InternetAddress.lookup(address);
+      if (resolvedAddress.isEmpty) {
+        throw Exception("Unable to resolve host");
+      }
+      await _connection
+          .connect(resolvedAddress.first, port)
           .then((Socket socket) {
         runZoned(() {
           _settings.client.value = ClientState.connected;

--- a/frosthaven_assistant/lib/services/network/network_info.dart
+++ b/frosthaven_assistant/lib/services/network/network_info.dart
@@ -12,21 +12,20 @@ import 'dart:async';
 import '../service_locator.dart';
 import 'network.dart';
 
-
 class NetworkInformation {
-
   NetworkInformation() {
     _connectivitySubscription =
-        _connectivity.onConnectivityChanged.listen((ConnectivityResult result){
-          if (_connectionStatus != result) {
-            if(_connectionStatus != null) { //null just to not show message on start.
-              getIt<Network>().networkMessage.value =
+        _connectivity.onConnectivityChanged.listen((ConnectivityResult result) {
+      if (_connectionStatus != result) {
+        if (_connectionStatus != null) {
+          //null just to not show message on start.
+          getIt<Network>().networkMessage.value =
               "Network connection: ${result.name}";
-            }
-          }
-          _connectionStatus = result;
-          initNetworkInfo();
-        });
+        }
+      }
+      _connectionStatus = result;
+      initNetworkInfo();
+    });
   }
 
   final NetworkInfo networkInfo = NetworkInfo();
@@ -37,12 +36,6 @@ class NetworkInformation {
 
   final wifiIPv4 = ValueNotifier<String>("");
   final outgoingIPv4 = ValueNotifier<String>("");
-  //final wifiName = ValueNotifier<String>("");
-  //final wifiBSSID = ValueNotifier<String>("");
-      //wifiIPv6,
-      //wifiGatewayIP,
-      //wifiBroadcast,
-      //wifiSubmask;
 
   Future<void> initNetworkInfo() async {
     try {
@@ -51,130 +44,37 @@ class NetworkInformation {
       outgoingIPv4.value = "";
     }
 
-    /*try {
-      if (!kIsWeb && Platform.isIOS) {
-        var status = await networkInfo.getLocationServiceAuthorization();
-        if (status == LocationAuthorizationStatus.notDetermined) {
-          status = await networkInfo.requestLocationServiceAuthorization();
-        }
-        if (status == LocationAuthorizationStatus.authorizedAlways ||
-            status == LocationAuthorizationStatus.authorizedWhenInUse) {
-          String? wifi = await networkInfo.getWifiName();
-          if(wifi != null) {
-            wifiName.value = wifi;
-          }
-        } else {
-          String? name = await networkInfo.getWifiName();
-          if(name != null) {
-            wifiName.value = name;
-          }
-        }
-      } else {
-        String? name = await networkInfo.getWifiName();
-        if(name != null) {
-          wifiName.value = name;
-        }
-      }
-    } on PlatformException catch (e) {
-      developer.log('Failed to get Wifi Name', error: e);
-      wifiName.value = 'Failed to get Wifi Name';
-    }*/
-
-    /*try {
-      if (!kIsWeb && Platform.isIOS) {
-        var status = await networkInfo.getLocationServiceAuthorization();
-        if (status == LocationAuthorizationStatus.notDetermined) {
-          status = await networkInfo.requestLocationServiceAuthorization();
-        }
-        if (status == LocationAuthorizationStatus.authorizedAlways ||
-            status == LocationAuthorizationStatus.authorizedWhenInUse) {
-          String? bssid = await networkInfo.getWifiBSSID();
-          if(bssid != null) {
-            wifiBSSID.value = bssid;
-          }
-        } else {
-          String? bssid = await networkInfo.getWifiBSSID();
-          if(bssid != null) {
-            wifiBSSID.value = bssid;
-          }
-        }
-      } else {
-        String? bssid = await networkInfo.getWifiBSSID();
-        if(bssid != null) {
-          wifiBSSID.value = bssid;
-        }
-      }
-    } on PlatformException catch (e) {
-      developer.log('Failed to get Wifi BSSID', error: e);
-      wifiBSSID.value = 'Failed to get Wifi BSSID';
-    }*/
-
     try {
       String? ipv4 = await networkInfo.getWifiIP();
-      if(ipv4 != null) {
+      if (ipv4 != null) {
         wifiIPv4.value = ipv4;
       }
     } on PlatformException catch (e) {
       developer.log('Failed to get Wifi IPv4', error: e);
-      wifiIPv4.value = 'Failed to get Wifi IPv4';
+      wifiIPv4.value = "";
       for (var interface in await NetworkInterface.list()) {
         //searching for eth should fix the ethernet ip address issue on ethernet connections on windows and linux
-        if (interface.name.toLowerCase().contains("eth") && !interface.name.toLowerCase().contains("switch")) {
+        if (interface.name.toLowerCase().contains("eth") &&
+            !interface.name.toLowerCase().contains("switch") &&
+            !interface.name.toLowerCase().contains("veth")) {
           for (var address in interface.addresses) {
             if (address.type == InternetAddressType.IPv4) {
-              wifiIPv4.value = address.address; //default to ipv4 ethernet address if no wifi
+              wifiIPv4.value =
+                  address.address; //default to ipv4 ethernet address if no wifi
               break;
             }
           }
+          if (wifiIPv4.value != "") {
+            break;
+          }
         }
       }
-
+      if (wifiIPv4.value == "") {
+        wifiIPv4.value = "Failed to get Wifi IPv4";
+      }
     }
 
-    /*try {
-      wifiIPv6 = await networkInfo.getWifiIPv6();
-    } on PlatformException catch (e) {
-      developer.log('Failed to get Wifi IPv6', error: e);
-      wifiIPv6 = 'Failed to get Wifi IPv6';
-    }*/
-
-    /*try {
-      wifiSubmask = await networkInfo.getWifiSubmask();
-    } on PlatformException catch (e) {
-      developer.log('Failed to get Wifi submask address', error: e);
-      wifiSubmask = 'Failed to get Wifi submask address';
-    }*/
-
-    /*try {
-      wifiBroadcast = await networkInfo.getWifiBroadcast();
-    } on PlatformException catch (e) {
-      developer.log('Failed to get Wifi broadcast', error: e);
-      wifiBroadcast = 'Failed to get Wifi broadcast';
-    }*/
-
-    /*try {
-      wifiGatewayIP = await networkInfo.getWifiGatewayIP();
-    } on PlatformException catch (e) {
-      developer.log('Failed to get Wifi gateway address', error: e);
-      wifiGatewayIP = 'Failed to get Wifi gateway address';
-    }*/
-
-    /*try {
-      wifiSubmask = await networkInfo.getWifiSubmask();
-    } on PlatformException catch (e) {
-      developer.log('Failed to get Wifi submask', error: e);
-      wifiSubmask = 'Failed to get Wifi submask';
-    }*/
-
-    developer.log(
-	//'Wifi Name: ${wifiName.value}\n'
-          //'Wifi BSSID: ${wifiBSSID.value}\n'
-          'Wifi IPv4: ${wifiIPv4.value}\n'
-          'Outgoing IPv4: ${outgoingIPv4.value}\n'
-          //'Wifi Broadcast: $wifiBroadcast\n'
-          //'Wifi Gateway: $wifiGatewayIP\n'
-          //'Wifi Submask: $wifiSubmask\n'
-    );
-
+    developer.log('Wifi IPv4: ${wifiIPv4.value}\n'
+        'Outgoing IPv4: ${outgoingIPv4.value}\n');
   }
 }


### PR DESCRIPTION
For client.dart instead of using the raw address value I'm trying to use InternetAddress.lookup from some quick local testing that should continue to work with ipv4 addresses and potentially resolve for things like computer names.

For network_info.dart I removed the commented out code since that is persisted in git and shouldn't need to be there. I also attempted to address this issue https://github.com/Tarmslitaren/FrosthavenAssistant/issues/154 and at least the issue I was running into on my local where it was picking up on the WSL virtual ethernet adapter has been resolved. I don't think it is the cleanest since we are still doing it in a catch. I did this by adding a filter on veth to attempt to filter out the virtual ethernet adapters. Additionally, I noticed that inside the condition the break statement was only in the inner loop not for the outer loop, which resulted in the last adapter matching the criteria to be used instead of the first so I added a break statement if the inner loop finds and acceptable value. 