### PR TITLE
Fixed Issue with Remote Clients Behind NAT

### DIFF
--- a/frosthaven_assistant/lib/services/network/connection.dart
+++ b/frosthaven_assistant/lib/services/network/connection.dart
@@ -54,7 +54,7 @@ class Connection {
   }
 
   Iterable<Socket> _find(Socket socket) {
-    return _sockets.where((x) => x.remoteAddress == socket.remoteAddress);
+    return _sockets.where((x) => x.remoteAddress == socket.remoteAddress && x.remotePort == socket.remotePort);
   }
 
   void _destroy(Iterable<Socket> sockets) {


### PR DESCRIPTION
Original Issue: When multiple client applications are running on the same network and sharing the same external IP address, only 1 could be connected at any one time. As soon as a second client attempted to connect, the first client would be immediately disconnected. (This is a rare use case, but can occur with remote play).

Resolution: When adding a new connection, the application first checks for duplicate connections and closes them. This duplicate connection check only compared remote IP addresses, meaning it gave false positives for multiple clients behind common NAT configurations. This fix changes the duplicate check to confirm that both the IP address and remote port are the same before closing the connection.

NOTE: I have only been able to test this change on Windows devices, though it should be platform agnostic.