### PR TITLE
Correct some Frosthaven room data

### DIFF
--- a/frosthaven_assistant/assets/data/rooms/Frosthaven.json
+++ b/frosthaven_assistant/assets/data/rooms/Frosthaven.json
@@ -257,7 +257,7 @@
         },
         "Snow Imp": {
           "normal": [0, 2, 0],
-          "elite": [2, 2, 2]
+          "elite": [2, 2, 4]
         }
       }
     }
@@ -1519,7 +1519,7 @@
         },
         "Deep Terror (FH)": {
           "normal": [1, 2, 1],
-          "elite": [1, 1, 1]
+          "elite": [1, 1, 2]
         }
       }},{
       "91.3": {
@@ -1639,7 +1639,7 @@
       "65.2": {
         "Deep Terror (FH)": {
           "normal": [2, 2, 0],
-          "elite": [1, 3,4]
+          "elite": [1, 2, 4]
         },
         "Night Demon (FH)": {
           "normal": [2, 0, 0],
@@ -1784,7 +1784,7 @@
           "elite": [0, 1, 2]
         },
         "Ruined Machine": {
-          "normal": [0, 2, 0],
+          "normal": [0, 3, 0],
           "elite": [0, 0, 0]
         },
         "Steel Automaton": {
@@ -4319,7 +4319,7 @@
           "elite": [1, 1, 2]
         },
         "Steel Automaton": {
-          "normal": [1, 0, 2],
+          "normal": [1, 0, 3],
           "elite": [0, 1, 0]
         }
       }


### PR DESCRIPTION
In Frosthaven it is rare that the total monster count or elite monster count decreases when the player count increases.

I found around 50 examples where this happens in the current json file.

Most examples were not errors but I think I did find some corrections for sections 22.2 78.3 65.2 52.1 and 150.2