### PR TITLE
refactor(CharacterSelectMenu) Pull character list tile into it's own widget

### DIFF
--- a/frosthaven_assistant/lib/Layout/menus/add_character_menu.dart
+++ b/frosthaven_assistant/lib/Layout/menus/add_character_menu.dart
@@ -183,63 +183,61 @@ class AddCharacterMenuState extends State<AddCharacterMenu> {
             ])));
   }
 
-  Widget? characterTile(BuildContext context, int index) => ListTile(
-        leading: Image(
-          height: 40,
-          width: 40,
-          fit: BoxFit.contain,
-          color: _foundCharacters[index].hidden &&
-                      !_gameState.unlockedClasses
-                          .contains(_foundCharacters[index].name) ||
-                  _foundCharacters[index].name == "Escort" ||
-                  _foundCharacters[index].name == "Objective"
-              ? null
-              : _foundCharacters[index].color,
-          filterQuality: FilterQuality.medium,
-          image: AssetImage(
-              "assets/images/class-icons/${_foundCharacters[index].name}.png"),
-        ),
-        //iconColor: _foundCharacters[index].color,
-        title: Text(
-            _foundCharacters[index].hidden &&
-                    !_gameState.unlockedClasses
-                        .contains(_foundCharacters[index].name)
-                ? "???"
-                : _foundCharacters[index].name,
-            style: TextStyle(
-                fontSize: 18,
-                color: _characterAlreadyAdded(_foundCharacters[index].name)
-                    ? Colors.grey
-                    : Colors.black)),
-        trailing: Text("(${_foundCharacters[index].edition})",
-            style: const TextStyle(fontSize: 14, color: Colors.grey)),
-        onTap: () {
-          if (!_characterAlreadyAdded(_foundCharacters[index].name)) {
-            setState(() {
-              String display = _foundCharacters[index].name;
-              int count = 1;
-              if (_foundCharacters[index].name == "Objective" ||
-                  _foundCharacters[index].name == "Escort") {
-                //add a number to name if already exists
-                for (var item in _gameState.currentList) {
-                  if (item is Character &&
-                      item.characterClass.name ==
-                          _foundCharacters[index].name) {
-                    count++;
-                  }
-                }
-                if (count > 1) {
-                  display += " $count";
+  Widget? characterTile(BuildContext context, int index) {
+    CharacterClass character = _foundCharacters[index];
+    bool characterUnlocked =
+        _gameState.unlockedClasses.contains(character.name);
+    bool characterAlreadyAdded = _characterAlreadyAdded(character.name);
+    bool characterIsObjective = character.name == "Objective";
+    bool characterIsEscort = character.name == "Escort";
+
+    return ListTile(
+      leading: Image(
+        height: 40,
+        width: 40,
+        fit: BoxFit.contain,
+        color: character.hidden && !characterUnlocked ||
+                characterIsEscort ||
+                characterIsObjective
+            ? null
+            : character.color,
+        filterQuality: FilterQuality.medium,
+        image: AssetImage("assets/images/class-icons/${character.name}.png"),
+      ),
+      //iconColor: character.color,
+      title: Text(
+          character.hidden && !characterUnlocked ? "???" : character.name,
+          style: TextStyle(
+              fontSize: 18,
+              color: characterAlreadyAdded ? Colors.grey : Colors.black)),
+      trailing: Text("(${character.edition})",
+          style: const TextStyle(fontSize: 14, color: Colors.grey)),
+      onTap: () {
+        if (!characterAlreadyAdded) {
+          setState(() {
+            String display = character.name;
+            int count = 1;
+            if (characterIsObjective || characterIsEscort) {
+              //add a number to name if already exists
+              for (var item in _gameState.currentList) {
+                if (item is Character &&
+                    item.characterClass.name == character.name) {
+                  count++;
                 }
               }
-              AddCharacterCommand command =
-                  AddCharacterCommand(_foundCharacters[index].name, display, 1);
-              _gameState.action(command); //
-              //open level menu
-              openDialog(
-                  context, SetCharacterLevelMenu(character: command.character));
-            });
-          }
-        },
-      );
+              if (count > 1) {
+                display += " $count";
+              }
+            }
+            AddCharacterCommand command =
+                AddCharacterCommand(character.name, display, 1);
+            _gameState.action(command); //
+            //open level menu
+            openDialog(
+                context, SetCharacterLevelMenu(character: command.character));
+          });
+        }
+      },
+    );
+  }
 }

--- a/frosthaven_assistant/lib/Layout/menus/add_character_menu.dart
+++ b/frosthaven_assistant/lib/Layout/menus/add_character_menu.dart
@@ -132,6 +132,22 @@ class AddCharacterMenuState extends State<AddCharacterMenu> {
 
     //open level menu
     openDialog(context, SetCharacterLevelMenu(character: command.character));
+
+    //update UI to disable added character
+    setState(() {});
+  }
+
+  bool _characterAlreadyAdded(String newCharacter) {
+    if (newCharacter == "Escort" || newCharacter == "Objective") {
+      return false;
+    }
+    var characters = GameMethods.getCurrentCharacters();
+    for (var character in characters) {
+      if (character.characterClass.name == newCharacter) {
+        return true;
+      }
+    }
+    return false;
   }
 
   @override
@@ -172,7 +188,9 @@ class AddCharacterMenuState extends State<AddCharacterMenu> {
                               itemBuilder: (context, index) {
                                 return CharacterTile(
                                   character: _foundCharacters[index],
-                                  onAddCharacter: _addCharacter,
+                                  onSelect: _addCharacter,
+                                  disabled: _characterAlreadyAdded(
+                                      _foundCharacters[index].name),
                                 );
                               },
                             ))

--- a/frosthaven_assistant/lib/Layout/menus/add_character_menu.dart
+++ b/frosthaven_assistant/lib/Layout/menus/add_character_menu.dart
@@ -8,6 +8,7 @@ import '../../Resource/settings.dart';
 import '../../Resource/state/game_state.dart';
 import '../../Resource/ui_utils.dart';
 import '../../services/service_locator.dart';
+import 'character_tile.dart';
 
 class AddCharacterMenu extends StatefulWidget {
   const AddCharacterMenu({super.key});
@@ -199,85 +200,5 @@ class AddCharacterMenuState extends State<AddCharacterMenu> {
                         Navigator.pop(context);
                       }))
             ])));
-  }
-}
-
-class CharacterTile extends StatefulWidget {
-  // Constructor
-  const CharacterTile(
-      {super.key, required this.character, required this.onAddCharacter});
-
-  final CharacterClass character;
-  final void Function(CharacterClass) onAddCharacter;
-
-  @override
-  State<CharacterTile> createState() => _CharacterTileState();
-}
-
-class _CharacterTileState extends State<CharacterTile> {
-  final GameState _gameState = getIt<GameState>();
-  late bool characterAlreadyAdded;
-
-  @override
-  void initState() {
-    super.initState();
-    characterAlreadyAdded = _characterAlreadyAdded(widget.character.name);
-  }
-
-  bool _characterAlreadyAdded(String newCharacter) {
-    if (newCharacter == "Escort" || newCharacter == "Objective") {
-      return false;
-    }
-    var characters = GameMethods.getCurrentCharacters();
-    for (var character in characters) {
-      if (character.characterClass.name == newCharacter) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  void _handleAddCharacter() {
-    if (!characterAlreadyAdded) {
-      widget.onAddCharacter(widget.character);
-      setState(() {
-        characterAlreadyAdded = true;
-      });
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    bool characterUnlocked =
-        _gameState.unlockedClasses.contains(widget.character.name);
-    bool characterIsObjective = widget.character.name == "Objective";
-    bool characterIsEscort = widget.character.name == "Escort";
-
-    return ListTile(
-      leading: Image(
-        height: 40,
-        width: 40,
-        fit: BoxFit.contain,
-        color: widget.character.hidden && !characterUnlocked ||
-                characterIsEscort ||
-                characterIsObjective
-            ? null
-            : widget.character.color,
-        filterQuality: FilterQuality.medium,
-        image: AssetImage(
-            "assets/images/class-icons/${widget.character.name}.png"),
-      ),
-      //iconColor: character.color,
-      title: Text(
-          widget.character.hidden && !characterUnlocked
-              ? "???"
-              : widget.character.name,
-          style: TextStyle(
-              fontSize: 18,
-              color: characterAlreadyAdded ? Colors.grey : Colors.black)),
-      trailing: Text("(${widget.character.edition})",
-          style: const TextStyle(fontSize: 14, color: Colors.grey)),
-      onTap: _handleAddCharacter,
-    );
   }
 }

--- a/frosthaven_assistant/lib/Layout/menus/add_character_menu.dart
+++ b/frosthaven_assistant/lib/Layout/menus/add_character_menu.dart
@@ -155,65 +155,7 @@ class AddCharacterMenuState extends State<AddCharacterMenu> {
                             child: ListView.builder(
                               controller: _scrollController,
                               itemCount: _foundCharacters.length,
-                              itemBuilder: (context, index) => ListTile(
-                                leading: Image(
-                                  height: 40,
-                                  width: 40,
-                                  fit: BoxFit.contain,
-                                  color: _foundCharacters[index].hidden &&
-                                              !_gameState.unlockedClasses
-                                                  .contains(_foundCharacters[index].name) ||
-                                          _foundCharacters[index].name == "Escort" ||
-                                          _foundCharacters[index].name == "Objective"
-                                      ? null
-                                      : _foundCharacters[index].color,
-                                  filterQuality: FilterQuality.medium,
-                                  image: AssetImage(
-                                      "assets/images/class-icons/${_foundCharacters[index].name}.png"),
-                                ),
-                                //iconColor: _foundCharacters[index].color,
-                                title: Text(
-                                    _foundCharacters[index].hidden &&
-                                            !_gameState.unlockedClasses
-                                                .contains(_foundCharacters[index].name)
-                                        ? "???"
-                                        : _foundCharacters[index].name,
-                                    style: TextStyle(
-                                        fontSize: 18,
-                                        color: _characterAlreadyAdded(_foundCharacters[index].name)
-                                            ? Colors.grey
-                                            : Colors.black)),
-                                trailing: Text("(${_foundCharacters[index].edition})",
-                                    style: const TextStyle(fontSize: 14, color: Colors.grey)),
-                                onTap: () {
-                                  if (!_characterAlreadyAdded(_foundCharacters[index].name)) {
-                                    setState(() {
-                                      String display = _foundCharacters[index].name;
-                                      int count = 1;
-                                      if (_foundCharacters[index].name == "Objective" ||
-                                          _foundCharacters[index].name == "Escort") {
-                                        //add a number to name if already exists
-                                        for (var item in _gameState.currentList) {
-                                          if (item is Character &&
-                                              item.characterClass.name ==
-                                                  _foundCharacters[index].name) {
-                                            count++;
-                                          }
-                                        }
-                                        if (count > 1) {
-                                          display += " $count";
-                                        }
-                                      }
-                                      AddCharacterCommand command = AddCharacterCommand(
-                                          _foundCharacters[index].name, display, 1);
-                                      _gameState.action(command); //
-                                      //open level menu
-                                      openDialog(context,
-                                          SetCharacterLevelMenu(character: command.character));
-                                    });
-                                  }
-                                },
-                              ),
+                              itemBuilder: characterTile,
                             ))
                         : const Text(
                             'No results found',
@@ -240,4 +182,64 @@ class AddCharacterMenuState extends State<AddCharacterMenu> {
                       }))
             ])));
   }
+
+  Widget? characterTile(BuildContext context, int index) => ListTile(
+        leading: Image(
+          height: 40,
+          width: 40,
+          fit: BoxFit.contain,
+          color: _foundCharacters[index].hidden &&
+                      !_gameState.unlockedClasses
+                          .contains(_foundCharacters[index].name) ||
+                  _foundCharacters[index].name == "Escort" ||
+                  _foundCharacters[index].name == "Objective"
+              ? null
+              : _foundCharacters[index].color,
+          filterQuality: FilterQuality.medium,
+          image: AssetImage(
+              "assets/images/class-icons/${_foundCharacters[index].name}.png"),
+        ),
+        //iconColor: _foundCharacters[index].color,
+        title: Text(
+            _foundCharacters[index].hidden &&
+                    !_gameState.unlockedClasses
+                        .contains(_foundCharacters[index].name)
+                ? "???"
+                : _foundCharacters[index].name,
+            style: TextStyle(
+                fontSize: 18,
+                color: _characterAlreadyAdded(_foundCharacters[index].name)
+                    ? Colors.grey
+                    : Colors.black)),
+        trailing: Text("(${_foundCharacters[index].edition})",
+            style: const TextStyle(fontSize: 14, color: Colors.grey)),
+        onTap: () {
+          if (!_characterAlreadyAdded(_foundCharacters[index].name)) {
+            setState(() {
+              String display = _foundCharacters[index].name;
+              int count = 1;
+              if (_foundCharacters[index].name == "Objective" ||
+                  _foundCharacters[index].name == "Escort") {
+                //add a number to name if already exists
+                for (var item in _gameState.currentList) {
+                  if (item is Character &&
+                      item.characterClass.name ==
+                          _foundCharacters[index].name) {
+                    count++;
+                  }
+                }
+                if (count > 1) {
+                  display += " $count";
+                }
+              }
+              AddCharacterCommand command =
+                  AddCharacterCommand(_foundCharacters[index].name, display, 1);
+              _gameState.action(command); //
+              //open level menu
+              openDialog(
+                  context, SetCharacterLevelMenu(character: command.character));
+            });
+          }
+        },
+      );
 }

--- a/frosthaven_assistant/lib/Layout/menus/character_tile.dart
+++ b/frosthaven_assistant/lib/Layout/menus/character_tile.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+
+import '../../Model/character_class.dart';
+import '../../Resource/state/game_state.dart';
+import '../../services/service_locator.dart';
+
+class CharacterTile extends StatefulWidget {
+  // Constructor
+  const CharacterTile(
+      {super.key, required this.character, required this.onAddCharacter});
+
+  final CharacterClass character;
+  final void Function(CharacterClass) onAddCharacter;
+
+  @override
+  State<CharacterTile> createState() => _CharacterTileState();
+}
+
+class _CharacterTileState extends State<CharacterTile> {
+  final GameState _gameState = getIt<GameState>();
+  late bool characterAlreadyAdded;
+
+  @override
+  void initState() {
+    super.initState();
+    characterAlreadyAdded = _characterAlreadyAdded(widget.character.name);
+  }
+
+  bool _characterAlreadyAdded(String newCharacter) {
+    if (newCharacter == "Escort" || newCharacter == "Objective") {
+      return false;
+    }
+    var characters = GameMethods.getCurrentCharacters();
+    for (var character in characters) {
+      if (character.characterClass.name == newCharacter) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  void _handleAddCharacter() {
+    if (!characterAlreadyAdded) {
+      widget.onAddCharacter(widget.character);
+      setState(() {
+        characterAlreadyAdded = true;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    bool characterUnlocked =
+        _gameState.unlockedClasses.contains(widget.character.name);
+    bool characterIsObjective = widget.character.name == "Objective";
+    bool characterIsEscort = widget.character.name == "Escort";
+
+    return ListTile(
+      leading: Image(
+        height: 40,
+        width: 40,
+        fit: BoxFit.contain,
+        color: widget.character.hidden && !characterUnlocked ||
+                characterIsEscort ||
+                characterIsObjective
+            ? null
+            : widget.character.color,
+        filterQuality: FilterQuality.medium,
+        image: AssetImage(
+            "assets/images/class-icons/${widget.character.name}.png"),
+      ),
+      //iconColor: character.color,
+      title: Text(
+          widget.character.hidden && !characterUnlocked
+              ? "???"
+              : widget.character.name,
+          style: TextStyle(
+              fontSize: 18,
+              color: characterAlreadyAdded ? Colors.grey : Colors.black)),
+      trailing: Text("(${widget.character.edition})",
+          style: const TextStyle(fontSize: 14, color: Colors.grey)),
+      onTap: _handleAddCharacter,
+    );
+  }
+}

--- a/frosthaven_assistant/lib/Layout/menus/character_tile.dart
+++ b/frosthaven_assistant/lib/Layout/menus/character_tile.dart
@@ -4,80 +4,51 @@ import '../../Model/character_class.dart';
 import '../../Resource/state/game_state.dart';
 import '../../services/service_locator.dart';
 
-class CharacterTile extends StatefulWidget {
+class CharacterTile extends StatelessWidget {
   // Constructor
-  const CharacterTile(
-      {super.key, required this.character, required this.onAddCharacter});
+  CharacterTile(
+      {super.key,
+      required this.character,
+      required this.onSelect,
+      this.disabled = false});
 
   final CharacterClass character;
-  final void Function(CharacterClass) onAddCharacter;
-
-  @override
-  State<CharacterTile> createState() => _CharacterTileState();
-}
-
-class _CharacterTileState extends State<CharacterTile> {
+  final void Function(CharacterClass) onSelect;
+  final bool disabled;
   final GameState _gameState = getIt<GameState>();
-  late bool characterAlreadyAdded;
-
-  @override
-  void initState() {
-    super.initState();
-    characterAlreadyAdded = _characterAlreadyAdded(widget.character.name);
-  }
-
-  bool _characterAlreadyAdded(String newCharacter) {
-    if (newCharacter == "Escort" || newCharacter == "Objective") {
-      return false;
-    }
-    var characters = GameMethods.getCurrentCharacters();
-    for (var character in characters) {
-      if (character.characterClass.name == newCharacter) {
-        return true;
-      }
-    }
-    return false;
-  }
 
   void _handleAddCharacter() {
-    if (!characterAlreadyAdded) {
-      widget.onAddCharacter(widget.character);
-      setState(() {
-        characterAlreadyAdded = true;
-      });
+    if (!disabled) {
+      onSelect(character);
     }
   }
 
   @override
   Widget build(BuildContext context) {
     bool characterUnlocked =
-        _gameState.unlockedClasses.contains(widget.character.name);
-    bool characterIsObjective = widget.character.name == "Objective";
-    bool characterIsEscort = widget.character.name == "Escort";
+        _gameState.unlockedClasses.contains(character.name);
+    bool characterIsObjective = character.name == "Objective";
+    bool characterIsEscort = character.name == "Escort";
 
     return ListTile(
       leading: Image(
         height: 40,
         width: 40,
         fit: BoxFit.contain,
-        color: widget.character.hidden && !characterUnlocked ||
+        color: character.hidden && !characterUnlocked ||
                 characterIsEscort ||
                 characterIsObjective
             ? null
-            : widget.character.color,
+            : character.color,
         filterQuality: FilterQuality.medium,
-        image: AssetImage(
-            "assets/images/class-icons/${widget.character.name}.png"),
+        image: AssetImage("assets/images/class-icons/${character.name}.png"),
       ),
       //iconColor: character.color,
       title: Text(
-          widget.character.hidden && !characterUnlocked
-              ? "???"
-              : widget.character.name,
+          character.hidden && !characterUnlocked ? "???" : character.name,
           style: TextStyle(
-              fontSize: 18,
-              color: characterAlreadyAdded ? Colors.grey : Colors.black)),
-      trailing: Text("(${widget.character.edition})",
+              fontSize: 18, color: disabled ? Colors.grey : Colors.black)),
+      trailing: Text("(${character.edition})",
           style: const TextStyle(fontSize: 14, color: Colors.grey)),
       onTap: _handleAddCharacter,
     );

--- a/frosthaven_assistant/lib/Layout/menus/remove_character_menu.dart
+++ b/frosthaven_assistant/lib/Layout/menus/remove_character_menu.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 
+import '../../Model/character_class.dart';
 import '../../Resource/commands/remove_character_command.dart';
 import '../../Resource/state/game_state.dart';
 import '../../services/service_locator.dart';
+import './character_tile.dart';
 
 class RemoveCharacterMenu extends StatefulWidget {
   const RemoveCharacterMenu({super.key});
@@ -28,6 +30,19 @@ class RemoveCharacterMenuState extends State<RemoveCharacterMenu> {
         currentCharacters.add(data);
       }
     }
+
+    void removeCharacter(CharacterClass characterClassToRemove) {
+      setState(() {
+        int indexToRemove = currentCharacters.indexWhere(
+            (character) => character.characterClass == characterClassToRemove);
+
+        if (indexToRemove != -1) {
+          _gameState.action(
+              RemoveCharacterCommand([currentCharacters[indexToRemove]]));
+        }
+      });
+    }
+
     return Container(
         constraints: const BoxConstraints(maxWidth: 400),
         child: Card(
@@ -40,38 +55,19 @@ class RemoveCharacterMenuState extends State<RemoveCharacterMenu> {
               ListTile(
                 title: const Text("Remove All", style: TextStyle(fontSize: 18)),
                 onTap: () {
-                  _gameState.action(RemoveCharacterCommand(currentCharacters)); //
+                  _gameState
+                      .action(RemoveCharacterCommand(currentCharacters)); //
                   Navigator.pop(context);
                 },
               ),
               Expanded(
                 child: ListView.builder(
-                  itemCount: currentCharacters.length,
-                  itemBuilder: (context, index) => ListTile(
-                    leading: Image(
-                      height: 30,
-                      width: 30,
-                      filterQuality: FilterQuality.medium,
-                      fit: BoxFit.scaleDown,
-                      color: currentCharacters[index].characterClass.name == "Escort" ||
-                              currentCharacters[index].characterClass.name == "Objective"
-                          ? null
-                          : currentCharacters[index].characterClass.color,
-                      image: AssetImage(
-                          "assets/images/class-icons/${currentCharacters[index].characterClass.name}.png"),
-                    ),
-                    iconColor: currentCharacters[index].characterClass.color,
-                    title: Text(currentCharacters[index].characterState.display.value,
-                        style: const TextStyle(fontSize: 18)),
-                    trailing: Text("(${currentCharacters[index].characterClass.edition})",
-                        style: const TextStyle(fontSize: 14, color: Colors.grey)),
-                    onTap: () {
-                      setState(() {
-                        _gameState.action(RemoveCharacterCommand([currentCharacters[index]])); //
-                      });
-                    },
-                  ),
-                ),
+                    itemCount: currentCharacters.length,
+                    itemBuilder: (context, index) {
+                      return CharacterTile(
+                          character: currentCharacters[index].characterClass,
+                          onSelect: removeCharacter);
+                    }),
               ),
               const SizedBox(
                 height: 34,

--- a/frosthaven_assistant/test/Layout/menus/character_tile_test.dart
+++ b/frosthaven_assistant/test/Layout/menus/character_tile_test.dart
@@ -1,0 +1,183 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:get_it/get_it.dart';
+import 'package:frosthaven_assistant/Layout/menus/character_tile.dart';
+import 'package:frosthaven_assistant/Model/character_class.dart';
+import 'package:frosthaven_assistant/Resource/state/game_state.dart';
+import 'package:built_collection/built_collection.dart';
+
+class MockGameState extends Mock implements GameState {
+  @override
+  BuiltSet<String> get unlockedClasses => super.noSuchMethod(
+        Invocation.getter(#unlockedClasses),
+        returnValue: BuiltSet<String>(),
+        returnValueForMissingStub: BuiltSet<String>(),
+      );
+}
+
+Widget buildTestWidget(Widget child) {
+  return MaterialApp(
+    home: Material(
+      child: child,
+    ),
+  );
+}
+
+CharacterClass getTestCharacter({String name = 'CORE', bool hidden = false}) {
+  return CharacterClass(
+    'CORE', // name
+    const [10, 20, 30], // healthByLevel
+    'First', // edition
+    Colors.blue, // color
+    Colors.blueAccent, // colorSecondary
+    hidden, // hidden
+    const [], // summons
+  );
+}
+
+void main() {
+  final getIt = GetIt.instance;
+  late MockGameState mockGameState;
+
+  setUp(() {
+    mockGameState = MockGameState();
+    getIt.registerSingleton<GameState>(mockGameState);
+  });
+
+  tearDown(() {
+    getIt.reset();
+  });
+
+  testWidgets('CharacterTile displays character name and image correctly',
+      (WidgetTester tester) async {
+    CharacterClass character = getTestCharacter();
+
+    await tester.pumpWidget(buildTestWidget(
+      CharacterTile(
+        character: character,
+        onSelect: (CharacterClass character) {},
+      ),
+    ));
+
+    expect(find.text(character.name), findsOneWidget);
+    expect(find.byType(Image), findsOneWidget);
+  });
+
+  testWidgets('CharacterTile handles onTap correctly when not disabled',
+      (WidgetTester tester) async {
+    CharacterClass character = getTestCharacter();
+
+    bool isSelected = false;
+
+    await tester.pumpWidget(
+      buildTestWidget(
+        CharacterTile(
+          character: character,
+          onSelect: (CharacterClass character) {
+            isSelected = true;
+          },
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(ListTile));
+    await tester.pumpAndSettle();
+
+    expect(isSelected, true);
+  });
+
+  testWidgets('CharacterTile does not run onTap when disabled',
+      (WidgetTester tester) async {
+    CharacterClass character = getTestCharacter();
+
+    bool isSelected = false;
+
+    await tester.pumpWidget(
+      buildTestWidget(
+        CharacterTile(
+          character: character,
+          onSelect: (CharacterClass character) {
+            isSelected = true;
+          },
+          disabled: true,
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(ListTile));
+    await tester.pumpAndSettle();
+
+    expect(isSelected, false);
+  });
+
+  testWidgets('CharacterTile shows ??? for hidden characters when not unlocked',
+      (WidgetTester tester) async {
+    CharacterClass character = getTestCharacter(hidden: true);
+
+    final characterNames = BuiltSet<String>([]);
+
+    when(mockGameState.unlockedClasses).thenReturn(characterNames);
+
+    await tester.pumpWidget(
+      buildTestWidget(
+        CharacterTile(
+          character: character,
+          onSelect: (CharacterClass character) {},
+        ),
+      ),
+    );
+
+    expect(find.text('???'), findsOneWidget);
+  });
+
+  testWidgets('CharacterTile shows character name when unlocked',
+      (WidgetTester tester) async {
+    CharacterClass character = getTestCharacter();
+
+    final characterNames = BuiltSet<String>([character.name]);
+
+    when(mockGameState.unlockedClasses).thenReturn(characterNames);
+
+    await tester.pumpWidget(
+      buildTestWidget(
+        CharacterTile(
+          character: character,
+          onSelect: (CharacterClass character) {},
+        ),
+      ),
+    );
+
+    expect(find.text(character.name), findsOneWidget);
+  });
+
+  testWidgets(
+      'CharacterTile does not change color for objective and escort characters',
+      (WidgetTester tester) async {
+    CharacterClass objectiveCharacter = getTestCharacter(name: 'Objective');
+    CharacterClass excortCharacter = getTestCharacter(name: 'Escort');
+
+    await tester.pumpWidget(
+      buildTestWidget(
+        Column(
+          children: [
+            CharacterTile(
+              character: objectiveCharacter,
+              onSelect: (CharacterClass character) {},
+            ),
+            CharacterTile(
+              character: excortCharacter,
+              onSelect: (CharacterClass character) {},
+            ),
+          ],
+        ),
+      ),
+    );
+
+    final objectiveImage = tester.widget<Image>(find.byType(Image).at(0));
+    final escortImage = tester.widget<Image>(find.byType(Image).at(1));
+
+    expect(objectiveImage.color, objectiveCharacter.color);
+    expect(escortImage.color, excortCharacter.color);
+  });
+}


### PR DESCRIPTION
### What is this
This is a refactor I did to help get myself familiar with the codebase. It does not change any functionality. It does 2 things:
1. Pulls the ListTile for a character in the character select menu out into it's own widget
2. Takes some of the things we did repeatedly in that widget and pulls them into a var.

### Why?
Pulling these things out into variables should do a few things for us:
1. Makes things a little easier to read by giving them a meaningful name.
2. Gives us 1 spot in the code to tweak these should they ever need tweaked.
3. For the variables storing the return value of a function, it allows us to just run those calculations once instead of multiple times per character.

### Notes
This is by no means necessary. Again, we don't really gain any user facing benefits here, this was more for me (and other developers) to help make this bit of code just a tad easier to read.

I'm new to Flutter and happy to make changes/learn as I go. Please feel free to leave helpful suggestions or point me in the right direction if something I've done doesn't follow best practices or your preferences.