### PR TITLE
bug(Settings) Don't reset `Server IP Address` field when you hit `done` on the iOS keyboard

### DIFF
--- a/frosthaven_assistant/lib/Layout/menus/settings_menu.dart
+++ b/frosthaven_assistant/lib/Layout/menus/settings_menu.dart
@@ -28,6 +28,8 @@ class SettingsMenuState extends State<SettingsMenu> {
   final TextEditingController _serverTextController = TextEditingController();
   final TextEditingController _portTextController = TextEditingController();
 
+  final ScrollController scrollController = ScrollController();
+
   late Settings settings;
 
   @override
@@ -40,11 +42,9 @@ class SettingsMenuState extends State<SettingsMenu> {
     _portTextController.text = settings.lastKnownPort;
   }
 
-  final ScrollController scrollController = ScrollController();
-
   List<DropdownMenuItem<String>> getIPList() {
     List<DropdownMenuItem<String>> retVal = [];
-    for( var item in getIt<Network>().networkInfo.wifiIPv4List) {
+    for (var item in getIt<Network>().networkInfo.wifiIPv4List) {
       retVal.add(DropdownMenuItem<String>(value: item, child: Text(item)));
     }
     return retVal;

--- a/frosthaven_assistant/lib/Layout/menus/settings_menu.dart
+++ b/frosthaven_assistant/lib/Layout/menus/settings_menu.dart
@@ -25,10 +25,13 @@ class SettingsMenu extends StatefulWidget {
 final networkInfo = NetworkInfo();
 
 class SettingsMenuState extends State<SettingsMenu> {
+  late Settings settings;
+
   @override
   initState() {
     // at the beginning, all items are shown
     super.initState();
+    settings = getIt<Settings>();
     getIt<Network>().networkInfo.initNetworkInfo();
   }
 
@@ -47,8 +50,6 @@ class SettingsMenuState extends State<SettingsMenu> {
 
   @override
   Widget build(BuildContext context) {
-    Settings settings = getIt<Settings>();
-
     double screenWidth = MediaQuery.of(context).size.width;
     double referenceMinBarWidth = 40 * 6.5;
     double maxBarScale = screenWidth / referenceMinBarWidth;

--- a/frosthaven_assistant/lib/Layout/menus/settings_menu.dart
+++ b/frosthaven_assistant/lib/Layout/menus/settings_menu.dart
@@ -25,6 +25,8 @@ class SettingsMenu extends StatefulWidget {
 final networkInfo = NetworkInfo();
 
 class SettingsMenuState extends State<SettingsMenu> {
+  final TextEditingController _serverTextController = TextEditingController();
+
   late Settings settings;
 
   @override
@@ -33,9 +35,9 @@ class SettingsMenuState extends State<SettingsMenu> {
     super.initState();
     settings = getIt<Settings>();
     getIt<Network>().networkInfo.initNetworkInfo();
+    _serverTextController.text = settings.lastKnownConnection;
   }
 
-  final TextEditingController _serverTextController = TextEditingController();
   final TextEditingController _portTextController = TextEditingController();
 
   final ScrollController scrollController = ScrollController();
@@ -53,7 +55,6 @@ class SettingsMenuState extends State<SettingsMenu> {
     double screenWidth = MediaQuery.of(context).size.width;
     double referenceMinBarWidth = 40 * 6.5;
     double maxBarScale = screenWidth / referenceMinBarWidth;
-    _serverTextController.text = settings.lastKnownConnection;
     _portTextController.text = settings.lastKnownPort;
 
     return Card(

--- a/frosthaven_assistant/lib/Layout/menus/settings_menu.dart
+++ b/frosthaven_assistant/lib/Layout/menus/settings_menu.dart
@@ -26,6 +26,7 @@ final networkInfo = NetworkInfo();
 
 class SettingsMenuState extends State<SettingsMenu> {
   final TextEditingController _serverTextController = TextEditingController();
+  final TextEditingController _portTextController = TextEditingController();
 
   late Settings settings;
 
@@ -36,9 +37,8 @@ class SettingsMenuState extends State<SettingsMenu> {
     settings = getIt<Settings>();
     getIt<Network>().networkInfo.initNetworkInfo();
     _serverTextController.text = settings.lastKnownConnection;
+    _portTextController.text = settings.lastKnownPort;
   }
-
-  final TextEditingController _portTextController = TextEditingController();
 
   final ScrollController scrollController = ScrollController();
 
@@ -55,7 +55,6 @@ class SettingsMenuState extends State<SettingsMenu> {
     double screenWidth = MediaQuery.of(context).size.width;
     double referenceMinBarWidth = 40 * 6.5;
     double maxBarScale = screenWidth / referenceMinBarWidth;
-    _portTextController.text = settings.lastKnownPort;
 
     return Card(
         child: Scrollbar(


### PR DESCRIPTION
### What does this do?
This addresses a minor bug I discovered when editing the server IP address in settings on an iOS device. 

Currently, if you hit `done` on the iOS keyboard after updating the value for the text field, the value of the text field resets back to the `lastKnownConnection` value (gif below).

### How does it fix it?
Apparently hitting `done` on the iOS keyboard causes the widget to rebuild. We were setting the value for the server IP address text field and the port fields during the build process.

After some digging it sounds like it is actually best practice to set those default values in `initState`. This ensures that we set the default values once and not every time the widget rebuilds. 

### Notes
This also cleans up one very minor whitespace issue in a for loop and moves the final variables for this widget around a bit to make sure that they are available to `initState` and still all located in the same place.

### Gifs
| Before Change | After Change |
|--------|--------|
| ![CleanShot 2024-06-24 at 22 32 39](https://github.com/Tarmslitaren/FrosthavenAssistant/assets/39142975/187384a3-8fc7-4a1e-837b-337fc91b833f) | ![CleanShot 2024-06-25 at 09 06 08](https://github.com/Tarmslitaren/FrosthavenAssistant/assets/39142975/56db64cf-65e8-43f2-ae56-11e6ed239325) |