### PR TITLE
bug(Scenario 21) Fix number of normal living spirits

### DIFF
--- a/frosthaven_assistant/assets/data/rooms/Frosthaven.json
+++ b/frosthaven_assistant/assets/data/rooms/Frosthaven.json
@@ -1589,7 +1589,7 @@
     {
       "start": {
         "Living Spirit (FH)": {
-          "normal": [2, 1, 1],
+          "normal": [2, 1, 2],
           "elite": [0, 1, 1]
         },
         "Frost Demon (FH)": {


### PR DESCRIPTION
This fixes a bug reported [here](https://github.com/Tarmslitaren/FrosthavenAssistant/issues/224).

In scenario 21, with 4 players, there should be 1 elite  and 2 normal living spirits in the starting room.