### PR TITLE
CI: Build and publish Docker container to GitHub registry

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  - push
+
+jobs:
+  container:
+    name: Build docker container
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_TAG: >
+        ${{
+          github.ref == 'refs/heads/main' && 'latest' ||
+          github.ref == 'refs/heads/container' && 'testing' ||
+          'branch'
+        }}
+    defaults:
+      run:
+        working-directory: ./frosthaven_assistant_server
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Login to GitHub Container Registry
+        run: docker login ghcr.io -u ${GITHUB_ACTOR} -p "${{ secrets.GITHUB_TOKEN }}"
+      - name: Set DOCKER_TAG for tags
+        if: startsWith(github.ref, 'refs/tags')
+        run: |
+          export DOCKER_TAG=$(echo "${{ github.ref }}" | sed 's/^refs\/tags\/v//g')
+          echo "DOCKER_TAG=$DOCKER_TAG" >> "$GITHUB_ENV"
+      - name: Build docker container
+        run: docker build -t ghcr.io/${GITHUB_REPOSITORY}/server:$DOCKER_TAG .
+      - name: Publish docker container
+        if: vars.DOCKER_TAG != 'branch'
+        run: docker push ghcr.io/${GITHUB_REPOSITORY}/server:$DOCKER_TAG


### PR DESCRIPTION
Allows container to be run as something like `docker run -p 4567:4567 ghcr.io/dehnert/frosthaven-assistant/server:latest`, without needing to build it locally.

This makes the Docker container from #229 a little easier to use (and more likely to be up-to-date as releases happen). I think the container registry might not like the capital letters in the repo name; I can make it rewrite to all lowercase or lowercase with a dash if you want (I just renamed my repo -- not sure if there are other tools that dislike capital letters).