### PR TITLE
Fixes #235 by adding retaliate range 2 to sunless abyss

### DIFF
--- a/frosthaven_assistant/assets/data/editions/Frosthaven.json
+++ b/frosthaven_assistant/assets/data/editions/Frosthaven.json
@@ -907,7 +907,7 @@
         ["Face of Darkness", 651, false, 82,"%move% - 1", "*.........","%attack% + 1","[r]","%dark%%use%",  "^%disarm%", "[/r]"],
         ["Arresting Advance", 652, false, 32, "%move% + 1", "*.........","%attack% - 1","[r]","%ice%%use%",  "^%immobilize%", "[/r]"],
         ["Nothing Special", 653, false, 57, "%move% + 0", "*.........","%attack% + 0", "%dark%"],
-        ["Sunless Abyss", 654, false, 11, "%curse%", "^%range% 2","*.........","%shield% + 1", "*.........","%retaliate% + 2", "[r]","%ice%","Å.", "%dark%", "[/r]"],
+        ["Sunless Abyss", 654, false, 11, "%curse%", "^%range% 2","*.........","%shield% + 1", "*.........","%retaliate% + 2","^%range% 2", "[r]","%ice%","Å.", "%dark%", "[/r]"],
         ["Hateful Spikes", 655, false, 17,  "%attack% + 1","*.........","%retaliate% + 2", "%dark%"],
         ["Pull of the Grave", 656, true, 98, "%move% + 1", "*.........","%attack% - 3","^%bane%"],
         ["Call for Souls", 657, true, 78,  "Summon X normal","Living Spirits", "Å*", "^Where X is the Living","^^Doom's current hit point value", "^^divided by 5 (rounded down)," ,"^^up to a maximum of three."]


### PR DESCRIPTION
Verified the retaliate range with my own copy of the physical game

Before:
![Before](https://github.com/user-attachments/assets/f0a8344e-7027-4fa3-85c1-22cc559a6ea3)

After:
![After](https://github.com/user-attachments/assets/30c53cac-9ee6-4980-9025-d6c66d4b3452)

First time contributing to this, so not sure if anything else is required. Additionally was unsure about whether the retaliate ought to be `%retaliate% 2` (instead of the `%retaliate% + 2`)