### PR TITLE
Issue in scenario 93B that spawns Vermling Scout from GH instead of FH

### DIFF
--- a/frosthaven_assistant/assets/data/rooms/Frosthaven.json
+++ b/frosthaven_assistant/assets/data/rooms/Frosthaven.json
@@ -5080,7 +5080,7 @@
           "normal": [2, 1, 0],
           "elite": [0, 1, 2]
         },
-        "Vermling Scout": {
+        "Vermling Scout (FH)": {
           "normal": [0, 0, 0],
           "elite": [2, 2, 4]
         }


### PR DESCRIPTION
Hello !

I have seen this bug in the app for scenario 93B so I made the change.

In scenario 93B the initial setup spawns Vermling Scout from Gloomhaven instead of the Frosthaven ones. Visual cues are that the deck is red instead of orange and the Vermling Scout line appears 2 times one with the active monsters and one in the inactive monsters.