### PR TITLE
fix flutter version in workflow flutter.yml

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: '3.27.2'
           channel: 'stable' # or: 'beta', 'dev' or 'master'
       - run: flutter --version
           


### PR DESCRIPTION
Since project requires SDK version >=3.4.0 && <3.8.0 the latest flutter version is not valid.

Use latest valid flutter version 3.27.2.

https://docs.flutter.dev/install/archive#stable-channel