### PR TITLE
CI: Build and publish Docker container to GitHub registry, retry

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+
+jobs:
+  container:
+    name: Build docker container
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./frosthaven_assistant_server
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}/x-haven-server
+          tags: |
+            type=ref,event=branch,suffix=-dev
+            type=semver,pattern={{version}}
+            type=raw,value=latest,enable={{is_default_branch}}
+      
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./frosthaven_assistant_server
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Based off #232

- Limit to commits on main and tags starting with 'v'
- Use official docker actions to simplify
- Tags for latest,version releases, and dev