### PR TITLE
Rename docker server container

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -5,9 +5,6 @@ on:
       - main
     tags:
       - 'v*'
-  pull_request:
-    branches:
-      - main
 permissions:
   contents: read
   packages: write
@@ -21,28 +18,27 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository }}/x-haven-server
+          images: ghcr.io/${{ github.repository_owner }}/x-haven-server
           tags: |
-            type=ref,event=branch,suffix=-dev
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/main' }}
             type=semver,pattern={{version}}
             type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
-            type=ref,event=pr,prefix=pr-
-      
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Build and push
         uses: docker/build-push-action@v5
         with:

--- a/frosthaven_assistant_server/README.md
+++ b/frosthaven_assistant_server/README.md
@@ -1,15 +1,31 @@
 Library and simple standalone dart server for X-Haven Assistant
-I have pushed the container to Docker Hub here:
-https://hub.docker.com/r/aschneem/x-haven-server
-
-This is currently a manual process and may not be up-to-date
+Container builds are automatically pushed the GitHub Container registry here:
+https://github.com/Tarmslitaren/FrosthavenAssistant/pkgs/container/x-haven-server
 
 The pull command:
-```
-docker pull aschneem/x-haven-server
+```bash
+docker pull ghcr.io/tarmslitaren/x-haven-server:latest
 ```
 
 Running the container:
+```bash
+docker run -p 4567:4567 ghcr.io/tarmslitaren/x-haven-server
 ```
-docker run -p 4567:4567 aschneem/x-haven-server
+
+Docker docker-compose.yml example:
+```yaml
+version: "3.9"
+
+services:
+  x-haven-server:
+    image: ghcr.io/tarmslitaren/x-haven-server:latest
+    container_name: x-haven-server
+    ports:
+      - "4567:4567"
+    restart: unless-stopped
+```
+
+Usage:
+```bash
+docker compose up -d
 ```


### PR DESCRIPTION
- Accidentally included repo name, shortened to ghcr.io/tarmslitaren/x-haven-server
- Rename main-dev tag to just dev
- Updated docs
- No longer build for PRs (keep restriction to prevent pushing PR images in-case this is added back later)

Notes!

1. This won't create a latest tag until a release is cut, or you could manually upload the latest image.
2. You will need to manually delete the container with the old name and if you prefer a different container name, now is the time to change it.
3. If you want to upload to Docker Hub, you would need to set that up with secrets, etc.