### PR TITLE
Add timeout and cancellation for client connection attempts

### DIFF
--- a/frosthaven_assistant/lib/Layout/menus/SettingsMenu/settings_network_section.dart
+++ b/frosthaven_assistant/lib/Layout/menus/SettingsMenu/settings_network_section.dart
@@ -69,6 +69,13 @@ class SettingsNetworkSectionState extends State<SettingsNetworkSection> {
               return CheckboxListTile(
                   enabled: !widget.settings.server.value &&
                       widget.settings.client.value != ClientState.connecting,
+                  secondary: clientState == ClientState.connecting
+                      ? IconButton(
+                          icon: const Icon(Icons.close),
+                          tooltip: l10n.cancelConnect,
+                          onPressed: () => widget.client.cancelConnect(),
+                        )
+                      : null,
                   title: Text(connectionText),
                   value: connected,
                   onChanged: (bool? value) {

--- a/frosthaven_assistant/lib/Layout/menus/main_menu.dart
+++ b/frosthaven_assistant/lib/Layout/menus/main_menu.dart
@@ -192,6 +192,13 @@ class MainMenu extends StatelessWidget {
                     final l10n = AppLocalizations.of(context)!;
                     return CheckboxListTile(
                       enabled: !vm.isServer && !vm.isConnecting,
+                      secondary: vm.isConnecting
+                          ? IconButton(
+                              icon: const Icon(Icons.close),
+                              tooltip: l10n.cancelConnect,
+                              onPressed: vm.cancelClientConnection,
+                            )
+                          : null,
                       title: Text(vm.isConnected
                           ? l10n.connectedAsClient
                           : vm.isConnecting

--- a/frosthaven_assistant/lib/Layout/view_models/main_menu_view_model.dart
+++ b/frosthaven_assistant/lib/Layout/view_models/main_menu_view_model.dart
@@ -124,6 +124,8 @@ class MainMenuViewModel {
     }
   }
 
+  void cancelClientConnection() => _client.cancelConnect();
+
   void toggleServer() {
     _settings.lastKnownHostIP =
         "(${_network.networkInfo.wifiIPv6.value})";

--- a/frosthaven_assistant/lib/l10n/app_en.arb
+++ b/frosthaven_assistant/lib/l10n/app_en.arb
@@ -41,6 +41,8 @@
 
   "connectedAsClient": "Connected as Client",
   "connecting": "Connecting...",
+  "cancelConnect": "Cancel",
+  "connectionCancelled": "Connection cancelled",
   "connectAsClientWithIp": "Connect as Client ({ip})",
   "@connectAsClientWithIp": {
     "placeholders": {

--- a/frosthaven_assistant/lib/l10n/app_localizations.dart
+++ b/frosthaven_assistant/lib/l10n/app_localizations.dart
@@ -245,6 +245,18 @@ abstract class AppLocalizations {
   /// **'Connecting...'**
   String get connecting;
 
+  /// No description provided for @cancelConnect.
+  ///
+  /// In en, this message translates to:
+  /// **'Cancel'**
+  String get cancelConnect;
+
+  /// No description provided for @connectionCancelled.
+  ///
+  /// In en, this message translates to:
+  /// **'Connection cancelled'**
+  String get connectionCancelled;
+
   /// No description provided for @connectAsClientWithIp.
   ///
   /// In en, this message translates to:
@@ -920,8 +932,8 @@ abstract class AppLocalizations {
   /// No description provided for @addMinusOneCard.
   ///
   /// In en, this message translates to:
-  /// **'Add -1 card (added: {count})'**
-  String addMinusOneCard(int count);
+  /// **'{direction, select, added{Add -1 card (added: {count})} removed{Add -1 card (removed: {count})} other{Add -1 card ({count})}}'**
+  String addMinusOneCard(String direction, int count);
 
   /// No description provided for @removeMinusOneCard.
   ///

--- a/frosthaven_assistant/lib/l10n/app_localizations_de.dart
+++ b/frosthaven_assistant/lib/l10n/app_localizations_de.dart
@@ -83,6 +83,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get connecting => 'Verbinde...';
 
   @override
+  String get cancelConnect => 'Cancel';
+
+  @override
+  String get connectionCancelled => 'Connection cancelled';
+
+  @override
   String connectAsClientWithIp(String ip) {
     return 'Als Client verbinden ($ip)';
   }

--- a/frosthaven_assistant/lib/l10n/app_localizations_en.dart
+++ b/frosthaven_assistant/lib/l10n/app_localizations_en.dart
@@ -81,6 +81,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get connecting => 'Connecting...';
 
   @override
+  String get cancelConnect => 'Cancel';
+
+  @override
+  String get connectionCancelled => 'Connection cancelled';
+
+  @override
   String connectAsClientWithIp(String ip) {
     return 'Connect as Client ($ip)';
   }

--- a/frosthaven_assistant/lib/l10n/app_localizations_es.dart
+++ b/frosthaven_assistant/lib/l10n/app_localizations_es.dart
@@ -81,6 +81,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get connecting => 'Conectando…';
 
   @override
+  String get cancelConnect => 'Cancel';
+
+  @override
+  String get connectionCancelled => 'Connection cancelled';
+
+  @override
   String connectAsClientWithIp(String ip) {
     return 'Conectar como cliente ($ip)';
   }

--- a/frosthaven_assistant/lib/l10n/app_localizations_fr.dart
+++ b/frosthaven_assistant/lib/l10n/app_localizations_fr.dart
@@ -81,6 +81,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get connecting => 'Connexion en cours…';
 
   @override
+  String get cancelConnect => 'Cancel';
+
+  @override
+  String get connectionCancelled => 'Connection cancelled';
+
+  @override
   String connectAsClientWithIp(String ip) {
     return 'Se connecter ($ip)';
   }

--- a/frosthaven_assistant/lib/l10n/app_localizations_ko.dart
+++ b/frosthaven_assistant/lib/l10n/app_localizations_ko.dart
@@ -81,6 +81,12 @@ class AppLocalizationsKo extends AppLocalizations {
   String get connecting => '연결 중…';
 
   @override
+  String get cancelConnect => 'Cancel';
+
+  @override
+  String get connectionCancelled => 'Connection cancelled';
+
+  @override
   String connectAsClientWithIp(String ip) {
     return '클라이언트로 연결 ($ip)';
   }

--- a/frosthaven_assistant/lib/l10n/app_localizations_pl.dart
+++ b/frosthaven_assistant/lib/l10n/app_localizations_pl.dart
@@ -81,6 +81,12 @@ class AppLocalizationsPl extends AppLocalizations {
   String get connecting => 'Łączenie…';
 
   @override
+  String get cancelConnect => 'Cancel';
+
+  @override
+  String get connectionCancelled => 'Connection cancelled';
+
+  @override
   String connectAsClientWithIp(String ip) {
     return 'Połącz jako klient ($ip)';
   }

--- a/frosthaven_assistant/lib/l10n/app_localizations_ru.dart
+++ b/frosthaven_assistant/lib/l10n/app_localizations_ru.dart
@@ -81,6 +81,12 @@ class AppLocalizationsRu extends AppLocalizations {
   String get connecting => 'Подключение…';
 
   @override
+  String get cancelConnect => 'Cancel';
+
+  @override
+  String get connectionCancelled => 'Connection cancelled';
+
+  @override
   String connectAsClientWithIp(String ip) {
     return 'Подключиться ($ip)';
   }

--- a/frosthaven_assistant/lib/l10n/app_localizations_th.dart
+++ b/frosthaven_assistant/lib/l10n/app_localizations_th.dart
@@ -81,6 +81,12 @@ class AppLocalizationsTh extends AppLocalizations {
   String get connecting => 'กำลังเชื่อมต่อ…';
 
   @override
+  String get cancelConnect => 'Cancel';
+
+  @override
+  String get connectionCancelled => 'Connection cancelled';
+
+  @override
   String connectAsClientWithIp(String ip) {
     return 'เชื่อมต่อในฐานะไคลเอนต์ ($ip)';
   }

--- a/frosthaven_assistant/lib/l10n/app_localizations_zh.dart
+++ b/frosthaven_assistant/lib/l10n/app_localizations_zh.dart
@@ -81,6 +81,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get connecting => '连接中…';
 
   @override
+  String get cancelConnect => 'Cancel';
+
+  @override
+  String get connectionCancelled => 'Connection cancelled';
+
+  @override
   String connectAsClientWithIp(String ip) {
     return '作为客户端连接（$ip）';
   }

--- a/frosthaven_assistant/lib/services/network/client.dart
+++ b/frosthaven_assistant/lib/services/network/client.dart
@@ -18,6 +18,7 @@ import 'connection.dart';
 class Client {
   String _leftOverMessage = "";
   bool _serverResponsive = true;
+  bool _connectCancelled = false;
   final GameState _gameState;
   final Communication _communication;
   final Connection _connection;
@@ -52,6 +53,7 @@ class Client {
 
   Future<void> connect(String address) async {
     _serverResponsive = true;
+    _connectCancelled = false;
     try {
       int port = int.parse(_settings.lastKnownPort);
       debugPrint("port nr: ${port.toString()}");
@@ -78,12 +80,26 @@ class Client {
         },
       );
     } catch (error) {
-      debugPrint("client error: $error");
-      _setNetworkMessage(_l10n.clientError(error.toString()), isError: true);
+      if (_connectCancelled) {
+        debugPrint("client connect cancelled by user");
+        _setNetworkMessage(_l10n.connectionCancelled);
+      } else {
+        debugPrint("client error: $error");
+        _setNetworkMessage(_l10n.clientError(error.toString()), isError: true);
+      }
       _settings.client.value = ClientState.disconnected;
       _settings.connectClientOnStartup = false;
       _settings.saveToDisk();
+      _connectCancelled = false;
     }
+  }
+
+  /// Aborts an in-progress connection attempt started via [connect]. The
+  /// pending attempt then fails fast and is reported as cancelled rather than
+  /// as an error.
+  void cancelConnect() {
+    _connectCancelled = true;
+    _connection.cancelConnect();
   }
 
   bool _pinging =

--- a/frosthaven_assistant/lib/services/network/connection.dart
+++ b/frosthaven_assistant/lib/services/network/connection.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:developer';
 import 'dart:io';
@@ -5,7 +6,15 @@ import 'dart:io';
 import 'package:format/format.dart';
 
 class Connection {
+  static const Duration _lookupTimeout = Duration(seconds: 5);
+  static const Duration _connectTimeout = Duration(seconds: 10);
+
   final _sockets = <Socket>[];
+
+  // The in-progress connection attempt, if any. Kept so that an attempt which
+  // hangs (e.g. wrong IP, server down) can be aborted by the user instead of
+  // running indefinitely.
+  ConnectionTask<Socket>? _pendingConnectionTask;
 
   List<Socket> getAll() {
     return _sockets;
@@ -13,10 +22,33 @@ class Connection {
 
   Future<Socket> connect(String address, int port) async {
     final resolvedAddresses = await _resolveAddress(address);
-    final socket = await Socket.connect(resolvedAddresses.first, port);
-    add(socket);
+    // startConnect returns a cancelable task rather than awaiting the socket
+    // directly, so an in-progress attempt can be aborted via cancelConnect().
+    final task = await Socket.startConnect(resolvedAddresses.first, port);
+    _pendingConnectionTask = task;
+    try {
+      final socket = await task.socket.timeout(
+        _connectTimeout,
+        onTimeout: () {
+          task.cancel();
+          throw TimeoutException(
+              'Connection attempt timed out', _connectTimeout);
+        },
+      );
+      add(socket);
 
-    return socket;
+      return socket;
+    } finally {
+      _pendingConnectionTask = null;
+    }
+  }
+
+  /// Aborts an in-progress [connect] attempt, if one is pending. Safe to call
+  /// when nothing is connecting. The pending [connect] future then completes
+  /// with an error once the underlying socket attempt is torn down.
+  void cancelConnect() {
+    _pendingConnectionTask?.cancel();
+    _pendingConnectionTask = null;
   }
 
   void add(Socket socket) {
@@ -48,7 +80,7 @@ class Connection {
 
   Future<List<InternetAddress>> _resolveAddress(String address) async {
     List<InternetAddress> resolvedAddresses =
-        await InternetAddress.lookup(address);
+        await InternetAddress.lookup(address).timeout(_lookupTimeout);
     if (resolvedAddresses.isEmpty) {
       throw Exception("Unable to resolve host");
     }

--- a/frosthaven_assistant/test/services/connection_test.dart
+++ b/frosthaven_assistant/test/services/connection_test.dart
@@ -182,6 +182,28 @@ void main() {
     result.shouldBeFalse();
   });
 
+  test('cancelConnect is a safe no-op when nothing is connecting', () {
+    // arrange
+    final sut = Connection();
+
+    // act & assert — must not throw when there is no pending attempt
+    expect(sut.cancelConnect, returnsNormally);
+  });
+
+  test('connect can be cancelled and does not hang', () async {
+    // arrange — 192.0.2.1 is RFC 5737 TEST-NET-1: reserved and non-routable,
+    // so the attempt would otherwise hang until the connect timeout.
+    final sut = Connection();
+    final connectFuture = sut.connect('192.0.2.1', _randomPortNumber);
+
+    // act — abort the attempt shortly after it starts
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    sut.cancelConnect();
+
+    // assert — completes with an error well before the 10s connect timeout
+    await expectLater(connectFuture, throwsA(isA<Exception>()));
+  }, timeout: const Timeout(Duration(seconds: 8)));
+
   test('connect returns socket connected to', () async {
     // arrange
     final expectedAddress = InternetAddress('127.0.0.1');


### PR DESCRIPTION
**Problem**
A failed or hung connection attempt currently runs indefinitely with no way to back out — `Socket.connect()` and `InternetAddress.lookup()` have no timeout, and `disconnect()` only acts on already-established connections. Connecting to a wrong IP or a downed server leaves the UI stuck in the "connecting" state.

**Changes**
- `connection.dart`: resolve via `InternetAddress.lookup` with a 5s timeout; connect via `Socket.startConnect` so the in-progress attempt is held as a cancelable `ConnectionTask`. Adds a 10s connect timeout and a `cancelConnect()` that aborts a pending attempt.
- `client.dart`: exposes `cancelConnect()`; reports a user cancel as a neutral "Connection cancelled" message rather than an error.
- Main menu + settings network section: show a Cancel (✕) button while connecting, wired through `MainMenuViewModel.cancelClientConnection()`.
- l10n: adds `cancelConnect` / `connectionCancelled` strings (all locales regenerated).

**Testing**
- `connection_test.dart`: `cancelConnect()` is a safe no-op when idle, and an in-flight connect to a non-routable address cancels without hanging.
- `flutter analyze` clean.

**Known limitation**
Cancel can't abort during the DNS-lookup phase (only after `Socket.startConnect`); the 5s lookup timeout caps that window.