### PR TITLE
Rebuild the board when the scaling sliders change

### DIFF
--- a/frosthaven_assistant/lib/Layout/menus/SettingsMenu/settings_menu.dart
+++ b/frosthaven_assistant/lib/Layout/menus/SettingsMenu/settings_menu.dart
@@ -295,6 +295,10 @@ class SettingsMenuState extends State<SettingsMenu> {
                   settings.userScalingMainList.value = value;
                   setMaxWidth();
                   settings.saveToDisk();
+                  // Rebuild the board so the new scale applies immediately
+                  // (as the style toggle below does); without this the list
+                  // keeps its old size until the next state change.
+                  _gameState.updateList.notify();
                 });
               },
             ),
@@ -314,6 +318,7 @@ class SettingsMenuState extends State<SettingsMenu> {
                 setState(() {
                   settings.userScalingBars.value = value;
                   settings.saveToDisk();
+                  _gameState.updateList.notify();
                 });
               },
             ),

--- a/frosthaven_assistant/test/Layout/menus/settings_menu_test.dart
+++ b/frosthaven_assistant/test/Layout/menus/settings_menu_test.dart
@@ -406,5 +406,49 @@ void main() {
       getIt<GameState>().action(
           SetAllyDeckInOgGloomCommand(before, gameState: getIt<GameState>()));
     });
+
+    testWidgets('moving the Main List Scaling slider rebuilds the board',
+        (WidgetTester tester) async {
+      final gameState = getIt<GameState>();
+      final settings = getIt<Settings>();
+      final before = settings.userScalingMainList.value;
+      int notifications = 0;
+      void listener() => notifications++;
+      gameState.updateList.addListener(listener);
+      addTearDown(() => gameState.updateList.removeListener(listener));
+
+      await pumpMenu(tester);
+      final slider = find.byType(Slider).first; // Main List Scaling
+      await tester.ensureVisible(slider);
+      await tester.drag(slider, const Offset(-40, 0));
+      await tester.pump();
+
+      expect(notifications, greaterThan(0),
+          reason:
+              'changing the main-list scale must notify the board to rebuild');
+      settings.userScalingMainList.value = before;
+    });
+
+    testWidgets('moving the App Bar Scaling slider rebuilds the board',
+        (WidgetTester tester) async {
+      final gameState = getIt<GameState>();
+      final settings = getIt<Settings>();
+      final before = settings.userScalingBars.value;
+      int notifications = 0;
+      void listener() => notifications++;
+      gameState.updateList.addListener(listener);
+      addTearDown(() => gameState.updateList.removeListener(listener));
+
+      await pumpMenu(tester);
+      final slider = find.byType(Slider).at(1); // App Bar Scaling
+      await tester.ensureVisible(slider);
+      await tester.drag(slider, const Offset(-40, 0));
+      await tester.pump();
+
+      expect(notifications, greaterThan(0),
+          reason:
+              'changing the app-bar scale must notify the board to rebuild');
+      settings.userScalingBars.value = before;
+    });
   });
 }


### PR DESCRIPTION
**Problem**
The **Main List Scaling** and **App Bar Scaling** sliders in Settings update and save the setting, but never notify the board to rebuild — so a new scale only takes effect after the next state change (e.g. toggling the Frosthaven / Gloomhaven style, which does notify). This is especially visible on a second device in a synced session: adjusting the scale appears to do nothing until an unrelated update forces a relayout.

**Fix**
Call `_gameState.updateList.notify()` from both sliders' `onChanged`, matching what the style selector directly below already does.

**Testing**
- Adds regression tests asserting each slider notifies the board.
- `flutter analyze` clean.