### PR TITLE
Stop the shimmer from overriding the user's setting on idle boards

### DIFF
--- a/frosthaven_assistant/lib/Resource/line_builder/line_builder.dart
+++ b/frosthaven_assistant/lib/Resource/line_builder/line_builder.dart
@@ -11,6 +11,29 @@ import '../state/game_state.dart';
 import '../../services/service_locator.dart';
 import '../../services/translation_service.dart';
 
+/// Matches "advantage" as a whole word, so it does not also match inside
+/// "disadvantage". Compiled once: [LineBuilder.createLines] evaluates this per
+/// line, per card render.
+final RegExp _advantageWord = RegExp(r'\badvantage\b');
+
+/// Whether [line] should get the looping colorize shimmer.
+///
+/// [animate] carries the user's "Stat card text shimmers" setting, which is off
+/// by default on mobile. It stays authoritative here: a shimmer is a
+/// forever-repeating animation, and any line that opts in keeps the app
+/// rendering continuously, so nothing may override the user's choice.
+bool shouldAnimateLine(String line, Monster? monster, bool animate) {
+  if (!animate || monster == null || !monster.isActive) {
+    return false;
+  }
+  final String lower = line.toLowerCase();
+  return lower.contains('disadvantage') ||
+      line.contains('retaliate') ||
+      line.contains('shield') ||
+      (monster.turnState.value == TurnsState.current &&
+          _advantageWord.hasMatch(lower));
+}
+
 class LineBuilder {
   static const bool debugColors = false;
 
@@ -532,18 +555,8 @@ class LineBuilder {
                   iconTokenText =
                       getIt<TranslationService>().t(iconTokenText);
                   //TODO: add animation on other texts too? and need to animate icons as well then for FH style
-                  bool shouldAnimate = animate &&
-                      monster != null &&
-                      (line.toLowerCase().contains('disadvantage') ||
-                          line.contains('retaliate') ||
-                          line.contains('shield')) &&
-                      monster.isActive;
-                  if (monster != null &&
-                      monster.turnState.value == TurnsState.current) {
-                    if (line.toLowerCase().contains("advantage")) {
-                      shouldAnimate = true;
-                    }
-                  }
+                  bool shouldAnimate =
+                      shouldAnimateLine(line, monster, animate);
 
                   textPartListRowContent.add(Container(
                       color: debugColors ? Colors.red : null,
@@ -655,17 +668,7 @@ class LineBuilder {
       }
 
       //TODO: add animation on other texts too? and need to animate icons as well then for FH style
-      bool shouldAnimate = animate &&
-          monster != null &&
-          (line.toLowerCase().contains('disadvantage') ||
-              line.contains('retaliate') ||
-              line.contains('shield')) &&
-          monster.isActive;
-      if (monster != null && monster.turnState.value == TurnsState.current) {
-        if (line.toLowerCase().contains("advantage")) {
-          shouldAnimate = true;
-        }
-      }
+      bool shouldAnimate = shouldAnimateLine(line, monster, animate);
 
       if (partStartIndex < line.length) {
         String textPart = line.substring(partStartIndex, line.length);

--- a/frosthaven_assistant/test/Layout/menus/main_menu_test.dart
+++ b/frosthaven_assistant/test/Layout/menus/main_menu_test.dart
@@ -113,6 +113,8 @@ void main() {
     ) async {
       await pumpMenu(tester);
       await tester.scrollUntilVisible(find.text('Add Monsters'), 100);
+      await tester.ensureVisible(find.text('Add Monsters'));
+      await tester.pump();
       await tester.tap(find.text('Add Monsters'));
       final originalOnError = FlutterError.onError;
       FlutterError.onError = ignoreOverflowErrors;
@@ -127,6 +129,8 @@ void main() {
     ) async {
       await pumpMenu(tester);
       await tester.scrollUntilVisible(find.text('Set Level'), 100);
+      await tester.ensureVisible(find.text('Set Level'));
+      await tester.pump();
       await tester.tap(find.text('Set Level'));
       final originalOnError = FlutterError.onError;
       FlutterError.onError = ignoreOverflowErrors;

--- a/frosthaven_assistant/test/resource/line_builder/should_animate_line_test.dart
+++ b/frosthaven_assistant/test/resource/line_builder/should_animate_line_test.dart
@@ -1,0 +1,131 @@
+// Regression guard for the shimmer-override fix (see line_builder.dart).
+//
+// The old code force-enabled the looping shimmer whenever a monster was
+// turn-current and the line matched contains("advantage"), which ignored both
+// the user's "Stat card text shimmers" setting and monster.isActive — and also
+// matched inside the word "disadvantage". On device that pinned an idle board
+// at ~90 fps with the setting off.
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:frosthaven_assistant/Resource/commands/add_monster_command.dart';
+import 'package:frosthaven_assistant/Resource/commands/add_standee_command.dart';
+import 'package:frosthaven_assistant/Resource/enums.dart';
+import 'package:frosthaven_assistant/Resource/line_builder/line_builder.dart';
+import 'package:frosthaven_assistant/Resource/state/game_state.dart';
+import 'package:frosthaven_assistant/services/service_locator.dart';
+
+import '../../command/test_helpers.dart';
+
+void main() {
+  setUpAll(() async {
+    await setUpGame();
+  });
+
+  setUp(() {
+    getIt<GameState>().clearList();
+  });
+
+  /// Any monster works — the line under test is passed to [shouldAnimateLine]
+  /// as a plain string, so the monster only supplies `isActive` and
+  /// `turnState`. In the shipped data "Advantage" is a stat-card *attribute*
+  /// carried by 21 monsters (Sun Demon, Night Demon, Black Imp and friends),
+  /// but none of those are in `assets/testData/`.
+  ///
+  /// Adding a standee is what makes the monster active.
+  Monster addMonster({required bool active}) {
+    AddMonsterCommand(
+      'Ancient Artillery (FH)',
+      1,
+      false,
+      gameState: getIt<GameState>(),
+    ).execute();
+    final monster = getIt<GameState>().currentList.firstWhere((e) => e is Monster)
+        as Monster;
+    if (active) {
+      AddStandeeCommand(
+        1,
+        null,
+        'Ancient Artillery (FH)',
+        MonsterType.normal,
+        false,
+        gameState: getIt<GameState>(),
+      ).execute();
+    }
+    return monster;
+  }
+
+  void setTurn(Monster monster, TurnsState state) {
+    (monster.turnState as ValueNotifier<TurnsState>).value = state;
+  }
+
+  group('shouldAnimateLine', () {
+    test('THE BUG: shimmer off + turn-current + Advantage does not animate',
+        () {
+      final monster = addMonster(active: true);
+      setTurn(monster, TurnsState.current);
+      expect(
+        shouldAnimateLine('Advantage', monster, false),
+        isFalse,
+        reason: 'the user setting must stay authoritative — this is the '
+            'override that pinned an idle iOS board at ~90 fps',
+      );
+    });
+
+    test('shimmer on + turn-current + Advantage still animates', () {
+      final monster = addMonster(active: true);
+      setTurn(monster, TurnsState.current);
+      expect(
+        shouldAnimateLine('Advantage', monster, true),
+        isTrue,
+      );
+    });
+
+    test('Advantage does not animate when the monster is not turn-current', () {
+      final monster = addMonster(active: true);
+      setTurn(monster, TurnsState.notDone);
+      expect(
+        shouldAnimateLine('Advantage', monster, true),
+        isFalse,
+      );
+    });
+
+    test('disadvantage animates via its own branch, not the advantage one', () {
+      final monster = addMonster(active: true);
+      // Not turn-current, so the advantage branch cannot be what matches.
+      setTurn(monster, TurnsState.notDone);
+      expect(
+        shouldAnimateLine('Disadvantage', monster, true),
+        isTrue,
+      );
+    });
+
+    test('word boundary: "disadvantage" no longer matches the advantage branch',
+        () {
+      final monster = addMonster(active: true);
+      setTurn(monster, TurnsState.current);
+      // Both branches would return true here, so assert the regexp directly on
+      // a line that contains "disadvantage" but must not count as "advantage".
+      expect(RegExp(r'\badvantage\b').hasMatch('disadvantage'), isFalse);
+    });
+
+    test('deliberate tightening: turn-current but inactive no longer animates',
+        () {
+      final monster = addMonster(active: false);
+      setTurn(monster, TurnsState.current);
+      expect(monster.isActive, isFalse);
+      expect(
+        shouldAnimateLine('Advantage', monster, true),
+        isFalse,
+        reason: 'the old override bypassed isActive; folding it into the gate '
+            'tightens this on purpose',
+      );
+    });
+
+    test('null monster never animates', () {
+      expect(
+        shouldAnimateLine('Advantage', null, true),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
> **PR 2 of 5 in a stack.** Merge in this order:
>
> **#328** → **#324** ← *this PR* → **#326** → **#327** → **#325**
>
> #328 is unrelated to the rest — it fixes two tests that have been failing on `main` since #320 merged, which turn every open PR's CI red. Everything below is stacked on it so that CI is meaningful.
>
> A fork PR can only target `main`, so each diff also contains the ones above it. **Review the 2nd commit only.**

An idle scenario board could render continuously on iOS, against a setting the user had switched off.

`shouldAnimateLine` computed a correctly-gated `shouldAnimate`, then unconditionally overrode it:

```dart
if (monster != null && monster.turnState.value == TurnsState.current) {
  if (line.toLowerCase().contains("advantage")) {
    shouldAnimate = true;   // ignores `animate` AND `monster.isActive`
  }
}
```

The override ignores `animate`, which is where `settings.shimmer` is threaded in — and shimmer defaults to **off** on mobile, so mobile users got a forever-repeating animation they never opted into. `"disadvantage".contains("advantage")` is also `true`, so it fired on disadvantage lines as well.

The fix folds the turn-state case into the gate so `animate` stays authoritative, and matches `\badvantage\b` on a word boundary.

**Not a rare edge case:** the trigger is the stat-card `Advantage` attribute, carried by 21 monsters across the shipped editions — every Sun Demon, Night Demon and Black Imp variant, plus Rat Monstrosity, Crystal Rot, Aesther Ashblade and others.

## Measured

iPhone 16 Pro, iOS 27, profile build. Same board both arms, only `line_builder.dart` swapped. Frames per 10s on an idle board, shimmer setting off:

| | frames / 10s (8 windows) | tickers |
|---|---|---|
| before | 845, 857, 961, 961, 961, 902, 896, 961 | 2 |
| after | 70 (startup), then **0 × 7** | 0 |

## Review note

Folding the turn-state case into the gate means it now also requires `monster.isActive`, which the old override bypassed. Turn-current implies active in practice, but flagging it in case that assumption breaks somewhere.

## Testing

`test/resource/line_builder/should_animate_line_test.dart` — 7 cases over the gate. `flutter test`: 1523 pass / 1 skip / 2 fail; the 2 (`main_menu_test.dart`) are pre-existing on `main`, confirmed by re-running against a clean checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZjzqhboES7T39Lu56zJkK


