### PR TITLE
Cut per-frame render cost on the main list

### DIFF
--- a/frosthaven_assistant/lib/Layout/CharacterWidget/character_background_widget.dart
+++ b/frosthaven_assistant/lib/Layout/CharacterWidget/character_background_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../Resource/app_constants.dart';
 import '../../Resource/ui_utils.dart';
 import '../../Resource/state/game_state.dart';
 
@@ -113,7 +114,12 @@ class CharacterBackgroundWidget extends StatelessWidget {
               ? ColorFilter.mode(color, BlendMode.softLight)
               : ColorFilter.mode(colorSecondary, BlendMode.color),
           image: ResizeImage(AssetImage("assets/images/psd/character-bar.png"),
-              width: (CharacterBackgroundWidget._kWidth * scale).toInt(), height: (CharacterBackgroundWidget._kHeight * scale).toInt()),
+              width: quantizeDecodeSize(
+                  CharacterBackgroundWidget._kWidth * scale,
+                  quantum: kBarDecodeSizeQuantum),
+              height: quantizeDecodeSize(
+                  CharacterBackgroundWidget._kHeight * scale,
+                  quantum: kBarDecodeSizeQuantum)),
         ),
         shape: BoxShape.rectangle,
       ),

--- a/frosthaven_assistant/lib/Layout/CharacterWidget/character_icon_widget.dart
+++ b/frosthaven_assistant/lib/Layout/CharacterWidget/character_icon_widget.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 
+import '../../Resource/app_constants.dart';
 import '../../Resource/state/game_state.dart';
 
 class CharacterIconWidget extends StatelessWidget {
@@ -67,6 +68,8 @@ class CharacterIconWidget extends StatelessWidget {
                 child: Image.asset(
                   "assets/images/class-icons/$className.png",
                   height: scaledHeight * CharacterIconWidget._kIconSizeRatio,
+                  cacheHeight: decodeCapForLogicalSize(context,
+                      scaledHeight * CharacterIconWidget._kIconSizeRatio),
                   fit: BoxFit.contain,
                 ),
               )
@@ -76,8 +79,12 @@ class CharacterIconWidget extends StatelessWidget {
                 color: isCharacter ? character.characterClass.color : null,
                 filterQuality: FilterQuality.medium,
                 width: scaledHeight * CharacterIconWidget._kIconSizeRatio,
-                image: AssetImage(
-                    "assets/images/class-icons/${character.characterClass.name}.png"),
+                image: ResizeImage(
+                    AssetImage(
+                        "assets/images/class-icons/${character.characterClass.name}.png"),
+                    height: decodeCapForLogicalSize(context,
+                        scaledHeight * CharacterIconWidget._kIconSizeRatio),
+                    policy: ResizeImagePolicy.fit),
               ));
   }
 }

--- a/frosthaven_assistant/lib/Layout/CharacterWidget/character_widget.dart
+++ b/frosthaven_assistant/lib/Layout/CharacterWidget/character_widget.dart
@@ -139,8 +139,6 @@ class CharacterWidgetState extends State<CharacterWidget> {
                     initPreset: widget.initPreset,
                   ));
 
-              // Only apply ColorFiltered when actually graying out: the
-              // identity-matrix variant still creates a save layer on Impeller.
               final Widget characterContent =
                   _buildCharacterContent(vm, character, isCharacter, inner);
 
@@ -159,11 +157,8 @@ class CharacterWidgetState extends State<CharacterWidget> {
                         return buildMonsterBoxGrid(scale, character);
                       }),
                 ),
-                vm.notGrayScale
-                    ? characterContent
-                    : ColorFiltered(
-                        colorFilter: ColorFilter.matrix(grayScale),
-                        child: characterContent)
+                grayScaleIf(
+                    grayedOut: !vm.notGrayScale, child: characterContent)
               ]);
             }));
   }

--- a/frosthaven_assistant/lib/Layout/MonsterBox/monster_box_body.dart
+++ b/frosthaven_assistant/lib/Layout/MonsterBox/monster_box_body.dart
@@ -101,10 +101,8 @@ class MonsterBoxBody extends StatelessWidget {
     final health = data.health.value;
 
     return RepaintBoundary(
-        child: ColorFiltered(
-            colorFilter: vm.isSummonedThisTurn
-                ? ColorFilter.matrix(grayScale)
-                : ColorFilter.matrix(identity),
+        child: grayScaleIf(
+            grayedOut: vm.isSummonedThisTurn,
             child: Container(
                 padding: EdgeInsets.zero,
                 height: _kBoxHeight * scale,
@@ -133,7 +131,10 @@ class MonsterBoxBody extends StatelessWidget {
                       width: _kImageWidth * scale,
                       fit: BoxFit.cover,
                       filterQuality: FilterQuality.medium,
-                      image: AssetImage(imagePath),
+                      image: ResizeImage(AssetImage(imagePath),
+                          height: decodeCapForLogicalSize(
+                              context, _kImageHeight * scale),
+                          policy: ResizeImagePolicy.fit),
                     ),
                   ),
                   Positioned(

--- a/frosthaven_assistant/lib/Layout/MonsterWidget/monster_widget.dart
+++ b/frosthaven_assistant/lib/Layout/MonsterWidget/monster_widget.dart
@@ -89,39 +89,37 @@ class MonsterWidgetState extends State<MonsterWidget> {
     return ListenableBuilder(
         listenable: _vm.updateList,
         builder: (context, child) {
+          final Widget monsterRow = SizedBox(
+            height: _kScaledHeight * scale,
+            width: getMainListWidth(context),
+            child: Row(
+              children: [
+                _vm.showTurnTap
+                    ? InkWell(
+                        onTap: () {
+                          _vm.endTurn();
+                        },
+                        child: MonsterImagePart(
+                            data: widget.data,
+                            scale: scale,
+                            height: height,
+                            vm: _vm))
+                    : MonsterImagePart(
+                        data: widget.data,
+                        scale: scale,
+                        height: height,
+                        vm: _vm),
+                RepaintBoundary(
+                    child: MonsterAbilityCardWidget(data: widget.data)),
+                RepaintBoundary(
+                    child: MonsterStatCardWidget(data: widget.data)),
+              ],
+            ),
+          );
+
           return RepaintBoundary(
               child: Column(mainAxisSize: MainAxisSize.max, children: [
-            ColorFiltered(
-                colorFilter: _vm.isGrayScale
-                    ? ColorFilter.matrix(grayScale)
-                    : ColorFilter.matrix(identity),
-                child: SizedBox(
-                  height: _kScaledHeight * scale,
-                  width: getMainListWidth(context),
-                  child: Row(
-                    children: [
-                      _vm.showTurnTap
-                          ? InkWell(
-                              onTap: () {
-                                _vm.endTurn();
-                              },
-                              child: MonsterImagePart(
-                                  data: widget.data,
-                                  scale: scale,
-                                  height: height,
-                                  vm: _vm))
-                          : MonsterImagePart(
-                              data: widget.data,
-                              scale: scale,
-                              height: height,
-                              vm: _vm),
-                      RepaintBoundary(
-                          child: MonsterAbilityCardWidget(data: widget.data)),
-                      RepaintBoundary(
-                          child: MonsterStatCardWidget(data: widget.data)),
-                    ],
-                  ),
-                )),
+            grayScaleIf(grayedOut: _vm.isGrayScale, child: monsterRow),
             Container(
               margin: EdgeInsets.only(
                   left: _kMarginH * scale, right: _kMarginH * scale),

--- a/frosthaven_assistant/lib/Layout/background.dart
+++ b/frosthaven_assistant/lib/Layout/background.dart
@@ -30,10 +30,9 @@ class BackGround extends StatelessWidget {
                         ? 'assets/images/bg/bg.png'
                         : 'assets/images/bg/frosthaven-bg.png',
                   ),
-                  width: (MediaQuery.of(context).size.width).toInt(),
-                  height: (MediaQuery.of(context).size.height -
-                          _kBarHeightTotal * settings.userScalingBars.value)
-                      .toInt(),
+                  width: quantizeDecodeSize(MediaQuery.of(context).size.width),
+                  height: quantizeDecodeSize(MediaQuery.of(context).size.height -
+                      _kBarHeightTotal * settings.userScalingBars.value),
                   policy: ResizeImagePolicy.fit),
             )),
         child: child);

--- a/frosthaven_assistant/lib/Layout/bottom_bar.dart
+++ b/frosthaven_assistant/lib/Layout/bottom_bar.dart
@@ -48,8 +48,9 @@ class BottomBar extends StatelessWidget {
                                       opacity: vm.backgroundOpacity,
                                       image: ResizeImage(
                                           AssetImage(vm.backgroundImagePath),
-                                          height:
-                                              (kBarHeight * barScale).toInt()),
+                                          height: quantizeDecodeSize(
+                                              kBarHeight * barScale,
+                                              quantum: kBarDecodeSizeQuantum)),
                                       fit: BoxFit.cover,
                                       repeat: ImageRepeat.repeatX),
                                 ),

--- a/frosthaven_assistant/lib/Layout/top_bar.dart
+++ b/frosthaven_assistant/lib/Layout/top_bar.dart
@@ -64,9 +64,9 @@ class TopBar extends StatelessWidget {
                             AssetImage(darkMode
                                 ? 'assets/images/psd/gloomhaven-bar.png'
                                 : 'assets/images/psd/frosthaven-bar.png'),
-                            height: (kBarHeight *
-                                    settings.userScalingBars.value)
-                                .toInt()),
+                            height: quantizeDecodeSize(
+                                kBarHeight * settings.userScalingBars.value,
+                                quantum: kBarDecodeSizeQuantum)),
                       ),
                     ),
                   );

--- a/frosthaven_assistant/lib/Resource/app_constants.dart
+++ b/frosthaven_assistant/lib/Resource/app_constants.dart
@@ -79,6 +79,44 @@ const double kCloseButtonWidth = 100;      // width of the positioned close butt
 const int kMonsterImageCacheHeight = 75;   // cache height for monster list-tile images
 const int kCharacterIconCacheHeight = 80;  // cache height for character class icon images
 
+/// Default granularity for [quantizeDecodeSize], in pixels. Suits full-screen
+/// images, where a few dozen pixels of overshoot is irrelevant.
+const int kDecodeSizeQuantum = 64;
+
+/// Granularity for the top/bottom bar textures, which are only tens of pixels
+/// tall — [kDecodeSizeQuantum] would round every bar height to the same value
+/// and visibly change how the texture is sampled.
+const int kBarDecodeSizeQuantum = 8;
+
+/// Rounds a decode dimension up to a multiple of [quantum].
+///
+/// [ResizeImage] includes its target width/height in the image cache key, so
+/// feeding it raw `MediaQuery` values means every incidental size change —
+/// rotation, a safe-area inset, nudging a scale slider — mints a new key and
+/// forces a fresh decode of the source PNG. The backgrounds are multi-megabyte,
+/// so that decode is expensive. Quantizing keeps incidental changes on one
+/// cache entry; images are drawn with BoxFit, so slightly overshooting the
+/// decode size is not visible.
+int quantizeDecodeSize(double dimension,
+    {int quantum = kDecodeSizeQuantum}) {
+  if (dimension <= 0) {
+    return quantum;
+  }
+  return (dimension / quantum).ceil() * quantum;
+}
+
+/// Decode cap in physical pixels for an image laid out at [logicalSize].
+///
+/// Main-list images are otherwise decoded at full asset resolution and
+/// downscaled at paint time, which wastes both decode time and cache memory.
+/// Multiplying by the device pixel ratio keeps them sharp on retina displays;
+/// quantizing keeps a scale-slider drag from re-decoding on every frame.
+int decodeCapForLogicalSize(BuildContext context, double logicalSize) {
+  final double ratio = MediaQuery.maybeDevicePixelRatioOf(context) ?? 1.0;
+  return quantizeDecodeSize(logicalSize * ratio,
+      quantum: kBarDecodeSizeQuantum);
+}
+
 /// Screen breakpoints (shortest dimension compared against orientation-corrected value)
 const double kPhoneScreenMaxDimension = 600;
 const double kLargeTabletMinDimension = 1200;

--- a/frosthaven_assistant/lib/Resource/color_matrices.dart
+++ b/frosthaven_assistant/lib/Resource/color_matrices.dart
@@ -1,5 +1,20 @@
 //for use with ColorFiltered widget
 
+import 'package:flutter/widgets.dart';
+
+/// Wraps [child] in a grayscale [ColorFiltered] only when [grayedOut] is true.
+///
+/// Do not substitute an identity matrix for the "normal" case: ColorFiltered
+/// allocates an offscreen save layer regardless of the matrix, so an identity
+/// filter costs a full extra render pass per widget for no visual difference.
+Widget grayScaleIf({required bool grayedOut, required Widget child}) {
+  if (!grayedOut) {
+    return child;
+  }
+  return ColorFiltered(
+      colorFilter: const ColorFilter.matrix(grayScale), child: child);
+}
+
 const List<double> grayScale = [
 //R  G   B    A  Const
   0.2126, 0.59, 0.11, 0, 0, //

--- a/frosthaven_assistant/lib/Resource/line_builder/line_builder.dart
+++ b/frosthaven_assistant/lib/Resource/line_builder/line_builder.dart
@@ -11,6 +11,29 @@ import '../state/game_state.dart';
 import '../../services/service_locator.dart';
 import '../../services/translation_service.dart';
 
+/// Matches "advantage" as a whole word, so it does not also match inside
+/// "disadvantage". Compiled once: [LineBuilder.createLines] evaluates this per
+/// line, per card render.
+final RegExp _advantageWord = RegExp(r'\badvantage\b');
+
+/// Whether [line] should get the looping colorize shimmer.
+///
+/// [animate] carries the user's "Stat card text shimmers" setting, which is off
+/// by default on mobile. It stays authoritative here: a shimmer is a
+/// forever-repeating animation, and any line that opts in keeps the app
+/// rendering continuously, so nothing may override the user's choice.
+bool shouldAnimateLine(String line, Monster? monster, bool animate) {
+  if (!animate || monster == null || !monster.isActive) {
+    return false;
+  }
+  final String lower = line.toLowerCase();
+  return lower.contains('disadvantage') ||
+      line.contains('retaliate') ||
+      line.contains('shield') ||
+      (monster.turnState.value == TurnsState.current &&
+          _advantageWord.hasMatch(lower));
+}
+
 class LineBuilder {
   static const bool debugColors = false;
 
@@ -532,18 +555,8 @@ class LineBuilder {
                   iconTokenText =
                       getIt<TranslationService>().t(iconTokenText);
                   //TODO: add animation on other texts too? and need to animate icons as well then for FH style
-                  bool shouldAnimate = animate &&
-                      monster != null &&
-                      (line.toLowerCase().contains('disadvantage') ||
-                          line.contains('retaliate') ||
-                          line.contains('shield')) &&
-                      monster.isActive;
-                  if (monster != null &&
-                      monster.turnState.value == TurnsState.current) {
-                    if (line.toLowerCase().contains("advantage")) {
-                      shouldAnimate = true;
-                    }
-                  }
+                  bool shouldAnimate =
+                      shouldAnimateLine(line, monster, animate);
 
                   textPartListRowContent.add(Container(
                       color: debugColors ? Colors.red : null,
@@ -655,17 +668,7 @@ class LineBuilder {
       }
 
       //TODO: add animation on other texts too? and need to animate icons as well then for FH style
-      bool shouldAnimate = animate &&
-          monster != null &&
-          (line.toLowerCase().contains('disadvantage') ||
-              line.contains('retaliate') ||
-              line.contains('shield')) &&
-          monster.isActive;
-      if (monster != null && monster.turnState.value == TurnsState.current) {
-        if (line.toLowerCase().contains("advantage")) {
-          shouldAnimate = true;
-        }
-      }
+      bool shouldAnimate = shouldAnimateLine(line, monster, animate);
 
       if (partStartIndex < line.length) {
         String textPart = line.substring(partStartIndex, line.length);

--- a/frosthaven_assistant/lib/main_state.dart
+++ b/frosthaven_assistant/lib/main_state.dart
@@ -80,6 +80,12 @@ class MainState extends State<MyHomePage>
         break;
       case AppLifecycleState.paused:
         log("app in paused");
+        // Drop decoded images that nothing is currently displaying. Reduces the
+        // chance iOS reclaims memory from a backgrounded app, which would force
+        // a cold relaunch and a full asset re-decode.
+        // Not clearLiveImages(): those are still referenced by the mounted
+        // tree, so clearing them only forces a re-decode on resume.
+        PaintingBinding.instance.imageCache.clear();
         break;
       case AppLifecycleState.detached:
         log("app in detached");

--- a/frosthaven_assistant/test/Layout/menus/main_menu_test.dart
+++ b/frosthaven_assistant/test/Layout/menus/main_menu_test.dart
@@ -113,6 +113,8 @@ void main() {
     ) async {
       await pumpMenu(tester);
       await tester.scrollUntilVisible(find.text('Add Monsters'), 100);
+      await tester.ensureVisible(find.text('Add Monsters'));
+      await tester.pump();
       await tester.tap(find.text('Add Monsters'));
       final originalOnError = FlutterError.onError;
       FlutterError.onError = ignoreOverflowErrors;
@@ -127,6 +129,8 @@ void main() {
     ) async {
       await pumpMenu(tester);
       await tester.scrollUntilVisible(find.text('Set Level'), 100);
+      await tester.ensureVisible(find.text('Set Level'));
+      await tester.pump();
       await tester.tap(find.text('Set Level'));
       final originalOnError = FlutterError.onError;
       FlutterError.onError = ignoreOverflowErrors;

--- a/frosthaven_assistant/test/resource/line_builder/should_animate_line_test.dart
+++ b/frosthaven_assistant/test/resource/line_builder/should_animate_line_test.dart
@@ -1,0 +1,131 @@
+// Regression guard for the shimmer-override fix (see line_builder.dart).
+//
+// The old code force-enabled the looping shimmer whenever a monster was
+// turn-current and the line matched contains("advantage"), which ignored both
+// the user's "Stat card text shimmers" setting and monster.isActive — and also
+// matched inside the word "disadvantage". On device that pinned an idle board
+// at ~90 fps with the setting off.
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:frosthaven_assistant/Resource/commands/add_monster_command.dart';
+import 'package:frosthaven_assistant/Resource/commands/add_standee_command.dart';
+import 'package:frosthaven_assistant/Resource/enums.dart';
+import 'package:frosthaven_assistant/Resource/line_builder/line_builder.dart';
+import 'package:frosthaven_assistant/Resource/state/game_state.dart';
+import 'package:frosthaven_assistant/services/service_locator.dart';
+
+import '../../command/test_helpers.dart';
+
+void main() {
+  setUpAll(() async {
+    await setUpGame();
+  });
+
+  setUp(() {
+    getIt<GameState>().clearList();
+  });
+
+  /// Any monster works — the line under test is passed to [shouldAnimateLine]
+  /// as a plain string, so the monster only supplies `isActive` and
+  /// `turnState`. In the shipped data "Advantage" is a stat-card *attribute*
+  /// carried by 21 monsters (Sun Demon, Night Demon, Black Imp and friends),
+  /// but none of those are in `assets/testData/`.
+  ///
+  /// Adding a standee is what makes the monster active.
+  Monster addMonster({required bool active}) {
+    AddMonsterCommand(
+      'Ancient Artillery (FH)',
+      1,
+      false,
+      gameState: getIt<GameState>(),
+    ).execute();
+    final monster = getIt<GameState>().currentList.firstWhere((e) => e is Monster)
+        as Monster;
+    if (active) {
+      AddStandeeCommand(
+        1,
+        null,
+        'Ancient Artillery (FH)',
+        MonsterType.normal,
+        false,
+        gameState: getIt<GameState>(),
+      ).execute();
+    }
+    return monster;
+  }
+
+  void setTurn(Monster monster, TurnsState state) {
+    (monster.turnState as ValueNotifier<TurnsState>).value = state;
+  }
+
+  group('shouldAnimateLine', () {
+    test('THE BUG: shimmer off + turn-current + Advantage does not animate',
+        () {
+      final monster = addMonster(active: true);
+      setTurn(monster, TurnsState.current);
+      expect(
+        shouldAnimateLine('Advantage', monster, false),
+        isFalse,
+        reason: 'the user setting must stay authoritative — this is the '
+            'override that pinned an idle iOS board at ~90 fps',
+      );
+    });
+
+    test('shimmer on + turn-current + Advantage still animates', () {
+      final monster = addMonster(active: true);
+      setTurn(monster, TurnsState.current);
+      expect(
+        shouldAnimateLine('Advantage', monster, true),
+        isTrue,
+      );
+    });
+
+    test('Advantage does not animate when the monster is not turn-current', () {
+      final monster = addMonster(active: true);
+      setTurn(monster, TurnsState.notDone);
+      expect(
+        shouldAnimateLine('Advantage', monster, true),
+        isFalse,
+      );
+    });
+
+    test('disadvantage animates via its own branch, not the advantage one', () {
+      final monster = addMonster(active: true);
+      // Not turn-current, so the advantage branch cannot be what matches.
+      setTurn(monster, TurnsState.notDone);
+      expect(
+        shouldAnimateLine('Disadvantage', monster, true),
+        isTrue,
+      );
+    });
+
+    test('word boundary: "disadvantage" no longer matches the advantage branch',
+        () {
+      final monster = addMonster(active: true);
+      setTurn(monster, TurnsState.current);
+      // Both branches would return true here, so assert the regexp directly on
+      // a line that contains "disadvantage" but must not count as "advantage".
+      expect(RegExp(r'\badvantage\b').hasMatch('disadvantage'), isFalse);
+    });
+
+    test('deliberate tightening: turn-current but inactive no longer animates',
+        () {
+      final monster = addMonster(active: false);
+      setTurn(monster, TurnsState.current);
+      expect(monster.isActive, isFalse);
+      expect(
+        shouldAnimateLine('Advantage', monster, true),
+        isFalse,
+        reason: 'the old override bypassed isActive; folding it into the gate '
+            'tightens this on purpose',
+      );
+    });
+
+    test('null monster never animates', () {
+      expect(
+        shouldAnimateLine('Advantage', null, true),
+        isFalse,
+      );
+    });
+  });
+}

--- a/frosthaven_assistant/test/widget/character_icon_widget_test.dart
+++ b/frosthaven_assistant/test/widget/character_icon_widget_test.dart
@@ -121,7 +121,11 @@ void main() {
       await pumpIcon(tester, character, true);
 
       final img = tester.widget<Image>(find.byType(Image));
-      final assetImage = img.image as AssetImage;
+      // The provider is wrapped in a ResizeImage to cap decode size.
+      final provider = img.image;
+      final assetImage =
+          (provider is ResizeImage ? provider.imageProvider : provider)
+              as AssetImage;
       expect(assetImage.assetName, contains(character.characterClass.name));
     });
 


### PR DESCRIPTION
> **PR 3 of 5 in a stack.** Merge in this order:
>
> **#328** → **#324** → **#326** ← *this PR* → **#327** → **#325**
>
> #328 is unrelated to the rest — it fixes two tests that have been failing on `main` since #320 merged, which turn every open PR's CI red. Everything below is stacked on it so that CI is meaningful.
>
> A fork PR can only target `main`, so each diff also contains the ones above it. **Review the 3rd commit only.**

Four per-frame or per-resize costs with **no visual change**. Split out from #324 so the shimmer fix can be reviewed on its own.

- **Identity-matrix save layers** (`monster_widget.dart`, `monster_box_body.dart`). `ColorFiltered` allocates an offscreen save layer even when the matrix is the identity, so every monster row and standee box paid a full offscreen pass for no effect. Uses the pattern already in `character_widget.dart`, extracted as `grayScaleIf()`.
- **Decode targets quantized** (`background.dart`, `top_bar.dart`, `bottom_bar.dart`, `character_background_widget.dart`). `ResizeImage` includes target dimensions in its cache key, so any change to the bars-scale slider, orientation or safe-area insets minted a new key and forced a fresh decode of a 2.1 MB PNG. Rounding up to a quantum makes incidental changes reuse one entry.
- **Decode size capped** for always-visible images (`character_icon_widget.dart`, `monster_box_body.dart`), matching what the menus already do.
- **Image cache cleared on `AppLifecycleState.paused`.** Memory pressure, not power — it reduces the chance iOS jetsam-kills the app and forces a cold relaunch. Deliberately `clear()` and not `clearLiveImages()`, which would force a re-decode on resume.

## Honest scope

These made **no** measurable difference to idle power once #324 landed — an idle board renders zero frames either way. They reduce cost during interaction, which was not separately quantified. Included because they are small and low-risk; happy to drop any of them.

## Testing

`flutter test`: 1523 pass / 1 skip / 2 fail, the 2 pre-existing on `main` as noted in #324. `flutter analyze`: no new issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZjzqhboES7T39Lu56zJkK


