### PR TITLE
Stop the ping loops waking the radio while backgrounded

### DIFF
--- a/frosthaven_assistant/lib/Layout/CharacterWidget/character_background_widget.dart
+++ b/frosthaven_assistant/lib/Layout/CharacterWidget/character_background_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../Resource/app_constants.dart';
 import '../../Resource/ui_utils.dart';
 import '../../Resource/state/game_state.dart';
 
@@ -113,7 +114,12 @@ class CharacterBackgroundWidget extends StatelessWidget {
               ? ColorFilter.mode(color, BlendMode.softLight)
               : ColorFilter.mode(colorSecondary, BlendMode.color),
           image: ResizeImage(AssetImage("assets/images/psd/character-bar.png"),
-              width: (CharacterBackgroundWidget._kWidth * scale).toInt(), height: (CharacterBackgroundWidget._kHeight * scale).toInt()),
+              width: quantizeDecodeSize(
+                  CharacterBackgroundWidget._kWidth * scale,
+                  quantum: kBarDecodeSizeQuantum),
+              height: quantizeDecodeSize(
+                  CharacterBackgroundWidget._kHeight * scale,
+                  quantum: kBarDecodeSizeQuantum)),
         ),
         shape: BoxShape.rectangle,
       ),

--- a/frosthaven_assistant/lib/Layout/CharacterWidget/character_icon_widget.dart
+++ b/frosthaven_assistant/lib/Layout/CharacterWidget/character_icon_widget.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 
+import '../../Resource/app_constants.dart';
 import '../../Resource/state/game_state.dart';
 
 class CharacterIconWidget extends StatelessWidget {
@@ -67,6 +68,8 @@ class CharacterIconWidget extends StatelessWidget {
                 child: Image.asset(
                   "assets/images/class-icons/$className.png",
                   height: scaledHeight * CharacterIconWidget._kIconSizeRatio,
+                  cacheHeight: decodeCapForLogicalSize(context,
+                      scaledHeight * CharacterIconWidget._kIconSizeRatio),
                   fit: BoxFit.contain,
                 ),
               )
@@ -76,8 +79,12 @@ class CharacterIconWidget extends StatelessWidget {
                 color: isCharacter ? character.characterClass.color : null,
                 filterQuality: FilterQuality.medium,
                 width: scaledHeight * CharacterIconWidget._kIconSizeRatio,
-                image: AssetImage(
-                    "assets/images/class-icons/${character.characterClass.name}.png"),
+                image: ResizeImage(
+                    AssetImage(
+                        "assets/images/class-icons/${character.characterClass.name}.png"),
+                    height: decodeCapForLogicalSize(context,
+                        scaledHeight * CharacterIconWidget._kIconSizeRatio),
+                    policy: ResizeImagePolicy.fit),
               ));
   }
 }

--- a/frosthaven_assistant/lib/Layout/CharacterWidget/character_widget.dart
+++ b/frosthaven_assistant/lib/Layout/CharacterWidget/character_widget.dart
@@ -139,8 +139,6 @@ class CharacterWidgetState extends State<CharacterWidget> {
                     initPreset: widget.initPreset,
                   ));
 
-              // Only apply ColorFiltered when actually graying out: the
-              // identity-matrix variant still creates a save layer on Impeller.
               final Widget characterContent =
                   _buildCharacterContent(vm, character, isCharacter, inner);
 
@@ -159,11 +157,8 @@ class CharacterWidgetState extends State<CharacterWidget> {
                         return buildMonsterBoxGrid(scale, character);
                       }),
                 ),
-                vm.notGrayScale
-                    ? characterContent
-                    : ColorFiltered(
-                        colorFilter: ColorFilter.matrix(grayScale),
-                        child: characterContent)
+                grayScaleIf(
+                    grayedOut: !vm.notGrayScale, child: characterContent)
               ]);
             }));
   }

--- a/frosthaven_assistant/lib/Layout/MonsterBox/monster_box_body.dart
+++ b/frosthaven_assistant/lib/Layout/MonsterBox/monster_box_body.dart
@@ -101,10 +101,8 @@ class MonsterBoxBody extends StatelessWidget {
     final health = data.health.value;
 
     return RepaintBoundary(
-        child: ColorFiltered(
-            colorFilter: vm.isSummonedThisTurn
-                ? ColorFilter.matrix(grayScale)
-                : ColorFilter.matrix(identity),
+        child: grayScaleIf(
+            grayedOut: vm.isSummonedThisTurn,
             child: Container(
                 padding: EdgeInsets.zero,
                 height: _kBoxHeight * scale,
@@ -133,7 +131,10 @@ class MonsterBoxBody extends StatelessWidget {
                       width: _kImageWidth * scale,
                       fit: BoxFit.cover,
                       filterQuality: FilterQuality.medium,
-                      image: AssetImage(imagePath),
+                      image: ResizeImage(AssetImage(imagePath),
+                          height: decodeCapForLogicalSize(
+                              context, _kImageHeight * scale),
+                          policy: ResizeImagePolicy.fit),
                     ),
                   ),
                   Positioned(

--- a/frosthaven_assistant/lib/Layout/MonsterWidget/monster_widget.dart
+++ b/frosthaven_assistant/lib/Layout/MonsterWidget/monster_widget.dart
@@ -89,39 +89,37 @@ class MonsterWidgetState extends State<MonsterWidget> {
     return ListenableBuilder(
         listenable: _vm.updateList,
         builder: (context, child) {
+          final Widget monsterRow = SizedBox(
+            height: _kScaledHeight * scale,
+            width: getMainListWidth(context),
+            child: Row(
+              children: [
+                _vm.showTurnTap
+                    ? InkWell(
+                        onTap: () {
+                          _vm.endTurn();
+                        },
+                        child: MonsterImagePart(
+                            data: widget.data,
+                            scale: scale,
+                            height: height,
+                            vm: _vm))
+                    : MonsterImagePart(
+                        data: widget.data,
+                        scale: scale,
+                        height: height,
+                        vm: _vm),
+                RepaintBoundary(
+                    child: MonsterAbilityCardWidget(data: widget.data)),
+                RepaintBoundary(
+                    child: MonsterStatCardWidget(data: widget.data)),
+              ],
+            ),
+          );
+
           return RepaintBoundary(
               child: Column(mainAxisSize: MainAxisSize.max, children: [
-            ColorFiltered(
-                colorFilter: _vm.isGrayScale
-                    ? ColorFilter.matrix(grayScale)
-                    : ColorFilter.matrix(identity),
-                child: SizedBox(
-                  height: _kScaledHeight * scale,
-                  width: getMainListWidth(context),
-                  child: Row(
-                    children: [
-                      _vm.showTurnTap
-                          ? InkWell(
-                              onTap: () {
-                                _vm.endTurn();
-                              },
-                              child: MonsterImagePart(
-                                  data: widget.data,
-                                  scale: scale,
-                                  height: height,
-                                  vm: _vm))
-                          : MonsterImagePart(
-                              data: widget.data,
-                              scale: scale,
-                              height: height,
-                              vm: _vm),
-                      RepaintBoundary(
-                          child: MonsterAbilityCardWidget(data: widget.data)),
-                      RepaintBoundary(
-                          child: MonsterStatCardWidget(data: widget.data)),
-                    ],
-                  ),
-                )),
+            grayScaleIf(grayedOut: _vm.isGrayScale, child: monsterRow),
             Container(
               margin: EdgeInsets.only(
                   left: _kMarginH * scale, right: _kMarginH * scale),

--- a/frosthaven_assistant/lib/Layout/background.dart
+++ b/frosthaven_assistant/lib/Layout/background.dart
@@ -30,10 +30,9 @@ class BackGround extends StatelessWidget {
                         ? 'assets/images/bg/bg.png'
                         : 'assets/images/bg/frosthaven-bg.png',
                   ),
-                  width: (MediaQuery.of(context).size.width).toInt(),
-                  height: (MediaQuery.of(context).size.height -
-                          _kBarHeightTotal * settings.userScalingBars.value)
-                      .toInt(),
+                  width: quantizeDecodeSize(MediaQuery.of(context).size.width),
+                  height: quantizeDecodeSize(MediaQuery.of(context).size.height -
+                      _kBarHeightTotal * settings.userScalingBars.value),
                   policy: ResizeImagePolicy.fit),
             )),
         child: child);

--- a/frosthaven_assistant/lib/Layout/bottom_bar.dart
+++ b/frosthaven_assistant/lib/Layout/bottom_bar.dart
@@ -48,8 +48,9 @@ class BottomBar extends StatelessWidget {
                                       opacity: vm.backgroundOpacity,
                                       image: ResizeImage(
                                           AssetImage(vm.backgroundImagePath),
-                                          height:
-                                              (kBarHeight * barScale).toInt()),
+                                          height: quantizeDecodeSize(
+                                              kBarHeight * barScale,
+                                              quantum: kBarDecodeSizeQuantum)),
                                       fit: BoxFit.cover,
                                       repeat: ImageRepeat.repeatX),
                                 ),

--- a/frosthaven_assistant/lib/Layout/top_bar.dart
+++ b/frosthaven_assistant/lib/Layout/top_bar.dart
@@ -64,9 +64,9 @@ class TopBar extends StatelessWidget {
                             AssetImage(darkMode
                                 ? 'assets/images/psd/gloomhaven-bar.png'
                                 : 'assets/images/psd/frosthaven-bar.png'),
-                            height: (kBarHeight *
-                                    settings.userScalingBars.value)
-                                .toInt()),
+                            height: quantizeDecodeSize(
+                                kBarHeight * settings.userScalingBars.value,
+                                quantum: kBarDecodeSizeQuantum)),
                       ),
                     ),
                   );

--- a/frosthaven_assistant/lib/Resource/app_constants.dart
+++ b/frosthaven_assistant/lib/Resource/app_constants.dart
@@ -79,6 +79,44 @@ const double kCloseButtonWidth = 100;      // width of the positioned close butt
 const int kMonsterImageCacheHeight = 75;   // cache height for monster list-tile images
 const int kCharacterIconCacheHeight = 80;  // cache height for character class icon images
 
+/// Default granularity for [quantizeDecodeSize], in pixels. Suits full-screen
+/// images, where a few dozen pixels of overshoot is irrelevant.
+const int kDecodeSizeQuantum = 64;
+
+/// Granularity for the top/bottom bar textures, which are only tens of pixels
+/// tall — [kDecodeSizeQuantum] would round every bar height to the same value
+/// and visibly change how the texture is sampled.
+const int kBarDecodeSizeQuantum = 8;
+
+/// Rounds a decode dimension up to a multiple of [quantum].
+///
+/// [ResizeImage] includes its target width/height in the image cache key, so
+/// feeding it raw `MediaQuery` values means every incidental size change —
+/// rotation, a safe-area inset, nudging a scale slider — mints a new key and
+/// forces a fresh decode of the source PNG. The backgrounds are multi-megabyte,
+/// so that decode is expensive. Quantizing keeps incidental changes on one
+/// cache entry; images are drawn with BoxFit, so slightly overshooting the
+/// decode size is not visible.
+int quantizeDecodeSize(double dimension,
+    {int quantum = kDecodeSizeQuantum}) {
+  if (dimension <= 0) {
+    return quantum;
+  }
+  return (dimension / quantum).ceil() * quantum;
+}
+
+/// Decode cap in physical pixels for an image laid out at [logicalSize].
+///
+/// Main-list images are otherwise decoded at full asset resolution and
+/// downscaled at paint time, which wastes both decode time and cache memory.
+/// Multiplying by the device pixel ratio keeps them sharp on retina displays;
+/// quantizing keeps a scale-slider drag from re-decoding on every frame.
+int decodeCapForLogicalSize(BuildContext context, double logicalSize) {
+  final double ratio = MediaQuery.maybeDevicePixelRatioOf(context) ?? 1.0;
+  return quantizeDecodeSize(logicalSize * ratio,
+      quantum: kBarDecodeSizeQuantum);
+}
+
 /// Screen breakpoints (shortest dimension compared against orientation-corrected value)
 const double kPhoneScreenMaxDimension = 600;
 const double kLargeTabletMinDimension = 1200;

--- a/frosthaven_assistant/lib/Resource/color_matrices.dart
+++ b/frosthaven_assistant/lib/Resource/color_matrices.dart
@@ -1,5 +1,20 @@
 //for use with ColorFiltered widget
 
+import 'package:flutter/widgets.dart';
+
+/// Wraps [child] in a grayscale [ColorFiltered] only when [grayedOut] is true.
+///
+/// Do not substitute an identity matrix for the "normal" case: ColorFiltered
+/// allocates an offscreen save layer regardless of the matrix, so an identity
+/// filter costs a full extra render pass per widget for no visual difference.
+Widget grayScaleIf({required bool grayedOut, required Widget child}) {
+  if (!grayedOut) {
+    return child;
+  }
+  return ColorFiltered(
+      colorFilter: const ColorFilter.matrix(grayScale), child: child);
+}
+
 const List<double> grayScale = [
 //R  G   B    A  Const
   0.2126, 0.59, 0.11, 0, 0, //

--- a/frosthaven_assistant/lib/Resource/line_builder/line_builder.dart
+++ b/frosthaven_assistant/lib/Resource/line_builder/line_builder.dart
@@ -11,6 +11,29 @@ import '../state/game_state.dart';
 import '../../services/service_locator.dart';
 import '../../services/translation_service.dart';
 
+/// Matches "advantage" as a whole word, so it does not also match inside
+/// "disadvantage". Compiled once: [LineBuilder.createLines] evaluates this per
+/// line, per card render.
+final RegExp _advantageWord = RegExp(r'\badvantage\b');
+
+/// Whether [line] should get the looping colorize shimmer.
+///
+/// [animate] carries the user's "Stat card text shimmers" setting, which is off
+/// by default on mobile. It stays authoritative here: a shimmer is a
+/// forever-repeating animation, and any line that opts in keeps the app
+/// rendering continuously, so nothing may override the user's choice.
+bool shouldAnimateLine(String line, Monster? monster, bool animate) {
+  if (!animate || monster == null || !monster.isActive) {
+    return false;
+  }
+  final String lower = line.toLowerCase();
+  return lower.contains('disadvantage') ||
+      line.contains('retaliate') ||
+      line.contains('shield') ||
+      (monster.turnState.value == TurnsState.current &&
+          _advantageWord.hasMatch(lower));
+}
+
 class LineBuilder {
   static const bool debugColors = false;
 
@@ -532,18 +555,8 @@ class LineBuilder {
                   iconTokenText =
                       getIt<TranslationService>().t(iconTokenText);
                   //TODO: add animation on other texts too? and need to animate icons as well then for FH style
-                  bool shouldAnimate = animate &&
-                      monster != null &&
-                      (line.toLowerCase().contains('disadvantage') ||
-                          line.contains('retaliate') ||
-                          line.contains('shield')) &&
-                      monster.isActive;
-                  if (monster != null &&
-                      monster.turnState.value == TurnsState.current) {
-                    if (line.toLowerCase().contains("advantage")) {
-                      shouldAnimate = true;
-                    }
-                  }
+                  bool shouldAnimate =
+                      shouldAnimateLine(line, monster, animate);
 
                   textPartListRowContent.add(Container(
                       color: debugColors ? Colors.red : null,
@@ -655,17 +668,7 @@ class LineBuilder {
       }
 
       //TODO: add animation on other texts too? and need to animate icons as well then for FH style
-      bool shouldAnimate = animate &&
-          monster != null &&
-          (line.toLowerCase().contains('disadvantage') ||
-              line.contains('retaliate') ||
-              line.contains('shield')) &&
-          monster.isActive;
-      if (monster != null && monster.turnState.value == TurnsState.current) {
-        if (line.toLowerCase().contains("advantage")) {
-          shouldAnimate = true;
-        }
-      }
+      bool shouldAnimate = shouldAnimateLine(line, monster, animate);
 
       if (partStartIndex < line.length) {
         String textPart = line.substring(partStartIndex, line.length);

--- a/frosthaven_assistant/lib/main_state.dart
+++ b/frosthaven_assistant/lib/main_state.dart
@@ -80,6 +80,12 @@ class MainState extends State<MyHomePage>
         break;
       case AppLifecycleState.paused:
         log("app in paused");
+        // Drop decoded images that nothing is currently displaying. Reduces the
+        // chance iOS reclaims memory from a backgrounded app, which would force
+        // a cold relaunch and a full asset re-decode.
+        // Not clearLiveImages(): those are still referenced by the mounted
+        // tree, so clearing them only forces a re-decode on resume.
+        PaintingBinding.instance.imageCache.clear();
         break;
       case AppLifecycleState.detached:
         log("app in detached");

--- a/frosthaven_assistant/lib/services/network/client.dart
+++ b/frosthaven_assistant/lib/services/network/client.dart
@@ -54,6 +54,12 @@ class Client {
   Future<void> connect(String address) async {
     _serverResponsive = true;
     _connectCancelled = false;
+    _pingGeneration++;
+    // Bumping the generation retires any chain from a previous connection, so
+    // the old chain can no longer stand in for this one — clear the re-entrancy
+    // guard too, or a reconnect that happens without an intervening _cleanup()
+    // would end up with no ping chain at all.
+    _pinging = false;
     try {
       int port = int.parse(_settings.lastKnownPort);
       debugPrint("port nr: ${port.toString()}");
@@ -104,19 +110,45 @@ class Client {
 
   bool _pinging =
       false; //to not restart this ping sub process, if one is running
+
+  /// Bumped whenever a connection starts or ends. A scheduled ping captures the
+  /// value it was created under and drops out if it no longer matches, so a
+  /// pending [Future.delayed] left over from a previous connection cannot
+  /// attach itself to the next one.
+  ///
+  /// Without this, resuming from background produces two concurrent ping chains
+  /// on one socket: the thawed chain from the old connection plus the one
+  /// started by reconnect-on-resume. Beyond the doubled traffic, the two race
+  /// on [_serverResponsive] — one clears it, the other's pong sets it — which
+  /// makes the unresponsive-server watchdog unable to fire correctly at all.
+  int _pingGeneration = 0;
+
   void _sendPing() {
     if (_connection.established() &&
         _settings.client.value == ClientState.connected &&
         !_pinging) {
       _pinging = true;
+      final int generation = _pingGeneration;
       Future.delayed(const Duration(seconds: 12), () {
+        if (generation != _pingGeneration) {
+          return; //belongs to a connection that has since been replaced
+        }
+        _pinging = false;
+        // Skip the ping while backgrounded: waking the radio every 12s is
+        // disproportionately expensive on battery, and the watchdog below
+        // would otherwise fire on a socket the OS has frozen and force a
+        // spurious "server unresponsive" disconnect. Reschedule regardless so
+        // the chain is still alive when the app comes back to the foreground.
+        if (_network.appInBackground) {
+          _serverResponsive = true;
+          _sendPing();
+          return;
+        }
         if (_serverResponsive) {
           _communication.sendToAll("ping");
           _serverResponsive = false; //set back to true when get response
-          _pinging = false;
           _sendPing();
         } else {
-          _pinging = false;
           disconnect(_l10n.serverUnresponsive);
         }
       });
@@ -225,6 +257,7 @@ class Client {
     _gameState.resetCommandHistory();
     _leftOverMessage = "";
     _pinging = false;
+    _pingGeneration++;
 
     if (_network.appInBackground) {
       _network.clientDisconnectedWhileInBackground = true;

--- a/frosthaven_assistant/lib/services/network/server.dart
+++ b/frosthaven_assistant/lib/services/network/server.dart
@@ -178,13 +178,18 @@ class Server extends GameServer {
         !_pinging) {
       _pinging = true;
       Future.delayed(const Duration(seconds: 20), () {
+        _pinging = false;
         if (serverSocket == null || !_settings.server.value) {
-          _pinging = false;
-        } else {
-          send("ping");
-          _pinging = false;
-          sendPing();
+          return;
         }
+        // Skip the broadcast while backgrounded — the radio wakeup costs far
+        // more battery than the keepalive is worth. Keep rescheduling so the
+        // chain resumes on foreground. (Android hosting keeps its foreground
+        // service, which is what actually holds the connection open there.)
+        if (!getIt<Network>().appInBackground) {
+          send("ping");
+        }
+        sendPing();
       });
     }
   }

--- a/frosthaven_assistant/pubspec.lock
+++ b/frosthaven_assistant/pubspec.lock
@@ -274,7 +274,7 @@ packages:
     source: hosted
     version: "3.1.0"
   fake_async:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: fake_async
       sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"

--- a/frosthaven_assistant/pubspec.yaml
+++ b/frosthaven_assistant/pubspec.yaml
@@ -91,6 +91,7 @@ dev_dependencies:
   build: ^4.0.5
   source_gen: ^4.2.2
   fluent_assertions: ^0.5.1
+  fake_async: ^1.3.1
   build_test: any
   json_diff: ^0.2.1
   dart_code_metrics_presets: ^2.25.1

--- a/frosthaven_assistant/test/Layout/menus/main_menu_test.dart
+++ b/frosthaven_assistant/test/Layout/menus/main_menu_test.dart
@@ -113,6 +113,8 @@ void main() {
     ) async {
       await pumpMenu(tester);
       await tester.scrollUntilVisible(find.text('Add Monsters'), 100);
+      await tester.ensureVisible(find.text('Add Monsters'));
+      await tester.pump();
       await tester.tap(find.text('Add Monsters'));
       final originalOnError = FlutterError.onError;
       FlutterError.onError = ignoreOverflowErrors;
@@ -127,6 +129,8 @@ void main() {
     ) async {
       await pumpMenu(tester);
       await tester.scrollUntilVisible(find.text('Set Level'), 100);
+      await tester.ensureVisible(find.text('Set Level'));
+      await tester.pump();
       await tester.tap(find.text('Set Level'));
       final originalOnError = FlutterError.onError;
       FlutterError.onError = ignoreOverflowErrors;

--- a/frosthaven_assistant/test/resource/line_builder/should_animate_line_test.dart
+++ b/frosthaven_assistant/test/resource/line_builder/should_animate_line_test.dart
@@ -1,0 +1,131 @@
+// Regression guard for the shimmer-override fix (see line_builder.dart).
+//
+// The old code force-enabled the looping shimmer whenever a monster was
+// turn-current and the line matched contains("advantage"), which ignored both
+// the user's "Stat card text shimmers" setting and monster.isActive — and also
+// matched inside the word "disadvantage". On device that pinned an idle board
+// at ~90 fps with the setting off.
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:frosthaven_assistant/Resource/commands/add_monster_command.dart';
+import 'package:frosthaven_assistant/Resource/commands/add_standee_command.dart';
+import 'package:frosthaven_assistant/Resource/enums.dart';
+import 'package:frosthaven_assistant/Resource/line_builder/line_builder.dart';
+import 'package:frosthaven_assistant/Resource/state/game_state.dart';
+import 'package:frosthaven_assistant/services/service_locator.dart';
+
+import '../../command/test_helpers.dart';
+
+void main() {
+  setUpAll(() async {
+    await setUpGame();
+  });
+
+  setUp(() {
+    getIt<GameState>().clearList();
+  });
+
+  /// Any monster works — the line under test is passed to [shouldAnimateLine]
+  /// as a plain string, so the monster only supplies `isActive` and
+  /// `turnState`. In the shipped data "Advantage" is a stat-card *attribute*
+  /// carried by 21 monsters (Sun Demon, Night Demon, Black Imp and friends),
+  /// but none of those are in `assets/testData/`.
+  ///
+  /// Adding a standee is what makes the monster active.
+  Monster addMonster({required bool active}) {
+    AddMonsterCommand(
+      'Ancient Artillery (FH)',
+      1,
+      false,
+      gameState: getIt<GameState>(),
+    ).execute();
+    final monster = getIt<GameState>().currentList.firstWhere((e) => e is Monster)
+        as Monster;
+    if (active) {
+      AddStandeeCommand(
+        1,
+        null,
+        'Ancient Artillery (FH)',
+        MonsterType.normal,
+        false,
+        gameState: getIt<GameState>(),
+      ).execute();
+    }
+    return monster;
+  }
+
+  void setTurn(Monster monster, TurnsState state) {
+    (monster.turnState as ValueNotifier<TurnsState>).value = state;
+  }
+
+  group('shouldAnimateLine', () {
+    test('THE BUG: shimmer off + turn-current + Advantage does not animate',
+        () {
+      final monster = addMonster(active: true);
+      setTurn(monster, TurnsState.current);
+      expect(
+        shouldAnimateLine('Advantage', monster, false),
+        isFalse,
+        reason: 'the user setting must stay authoritative — this is the '
+            'override that pinned an idle iOS board at ~90 fps',
+      );
+    });
+
+    test('shimmer on + turn-current + Advantage still animates', () {
+      final monster = addMonster(active: true);
+      setTurn(monster, TurnsState.current);
+      expect(
+        shouldAnimateLine('Advantage', monster, true),
+        isTrue,
+      );
+    });
+
+    test('Advantage does not animate when the monster is not turn-current', () {
+      final monster = addMonster(active: true);
+      setTurn(monster, TurnsState.notDone);
+      expect(
+        shouldAnimateLine('Advantage', monster, true),
+        isFalse,
+      );
+    });
+
+    test('disadvantage animates via its own branch, not the advantage one', () {
+      final monster = addMonster(active: true);
+      // Not turn-current, so the advantage branch cannot be what matches.
+      setTurn(monster, TurnsState.notDone);
+      expect(
+        shouldAnimateLine('Disadvantage', monster, true),
+        isTrue,
+      );
+    });
+
+    test('word boundary: "disadvantage" no longer matches the advantage branch',
+        () {
+      final monster = addMonster(active: true);
+      setTurn(monster, TurnsState.current);
+      // Both branches would return true here, so assert the regexp directly on
+      // a line that contains "disadvantage" but must not count as "advantage".
+      expect(RegExp(r'\badvantage\b').hasMatch('disadvantage'), isFalse);
+    });
+
+    test('deliberate tightening: turn-current but inactive no longer animates',
+        () {
+      final monster = addMonster(active: false);
+      setTurn(monster, TurnsState.current);
+      expect(monster.isActive, isFalse);
+      expect(
+        shouldAnimateLine('Advantage', monster, true),
+        isFalse,
+        reason: 'the old override bypassed isActive; folding it into the gate '
+            'tightens this on purpose',
+      );
+    });
+
+    test('null monster never animates', () {
+      expect(
+        shouldAnimateLine('Advantage', null, true),
+        isFalse,
+      );
+    });
+  });
+}

--- a/frosthaven_assistant/test/services/client_test.dart
+++ b/frosthaven_assistant/test/services/client_test.dart
@@ -1,7 +1,9 @@
 // ignore_for_file: missing-test-assertion
 
 import 'dart:async';
+import 'dart:io';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:fluent_assertions/fluent_assertions.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -26,6 +28,7 @@ const _address = '127.0.0.1';
   MockSpec<Connection>(),
   MockSpec<Network>(),
   MockSpec<Settings>(),
+  MockSpec<Socket>(),
   MockSpec<ValueNotifier<String>>(as: Symbol('MockValueNotifierString')),
   MockSpec<ValueNotifier<ClientState>>(
       as: Symbol('MockValueNotifierClientState'))
@@ -64,6 +67,61 @@ void main() {
     // assert
     _log.any((element) => element.contains('port nr: 0')).shouldBeTrue();
   }));
+
+  // Regression guard for a bug observed on device: after the app resumes from
+  // background, the socket has been dropped and reconnect-on-resume opens a new
+  // one — but the previous connection's pending ping `Future.delayed` thaws and
+  // latches onto the replacement, so two chains ping the same socket forever.
+  // Beyond the doubled traffic they race on the responsive flag, which breaks
+  // the unresponsive-server watchdog.
+  test('a ping scheduled by a replaced connection does not keep pinging', () {
+    final connection = MockConnection();
+    final communication = MockCommunication();
+    final network = MockNetwork();
+    final settings = MockSettings();
+    final socket = MockSocket();
+
+    when(settings.lastKnownPort).thenReturn('4567');
+    when(settings.locale).thenReturn(ValueNotifier<String>('en'));
+    when(settings.client)
+        .thenReturn(ValueNotifier<ClientState>(ClientState.disconnected));
+    when(network.networkMessage).thenReturn(ValueNotifier<String>(''));
+    when(network.networkMessageIsError).thenReturn(ValueNotifier<bool>(false));
+    when(network.appInBackground).thenReturn(false);
+    when(socket.remoteAddress).thenReturn(InternetAddress('127.0.0.1'));
+    when(socket.remotePort).thenReturn(4567);
+    when(connection.connect(any, any)).thenAnswer((_) async => socket);
+    when(connection.established()).thenReturn(true);
+
+    final client = Client(
+      gameState: _gameState,
+      communication: communication,
+      connection: connection,
+      network: network,
+      settings: settings,
+    );
+
+    fakeAsync((async) {
+      client.connect(_address); // chain A, would ping at t=12s
+      async.elapse(const Duration(seconds: 6));
+
+      // The socket dies while the app is away; the resume path reconnects.
+      final onDone = verify(communication.listen(any, any, captureAny))
+          .captured
+          .last as void Function()?;
+      onDone?.call();
+      client.connect(_address); // chain B, pings at t=18s
+      async.elapse(const Duration(seconds: 14)); // to t=20s
+
+      // Only chain B is alive, and it has pinged once, at t=18s.
+      verify(communication.sendToAll('ping')).called(1);
+
+      // Before the fix chain A also fired, at t=12s, and cleared the responsive
+      // flag out from under chain B — so chain B read a pong it had no reason
+      // to expect yet and force-disconnected a perfectly healthy connection.
+      settings.client.value.shouldBe(ClientState.connected);
+    });
+  });
 }
 
 void Function() _overridePrint(void Function() testFn) => () {

--- a/frosthaven_assistant/test/widget/character_icon_widget_test.dart
+++ b/frosthaven_assistant/test/widget/character_icon_widget_test.dart
@@ -121,7 +121,11 @@ void main() {
       await pumpIcon(tester, character, true);
 
       final img = tester.widget<Image>(find.byType(Image));
-      final assetImage = img.image as AssetImage;
+      // The provider is wrapped in a ResizeImage to cap decode size.
+      final provider = img.image;
+      final assetImage =
+          (provider is ResizeImage ? provider.imageProvider : provider)
+              as AssetImage;
       expect(assetImage.assetName, contains(character.characterClass.name));
     });
 


### PR DESCRIPTION
> **PR 4 of 5 in a stack.** Merge in this order:
>
> **#328** → **#324** → **#326** → **#327** ← *this PR* → **#325**
>
> #328 is unrelated to the rest — it fixes two tests that have been failing on `main` since #320 merged, which turn every open PR's CI red. Everything below is stacked on it so that CI is meaningful.
>
> A fork PR can only target `main`, so each diff also contains the ones above it. **Review the 4th commit only.**

Both ping chains are self-rescheduling `Future.delayed` loops that never checked `Network.appInBackground`, which the lifecycle handler already maintains — 12s on the client, 20s on the server, forever. Radio wakeups cost far more than their CPU time suggests.

Care was needed around `_serverResponsive`, a single-window watchdog that force-disconnects on one missed pong: the client resets it when pings resume rather than letting it fire against a socket the OS has frozen.

## Tested

Against a small Python peer that speaks the `S3nD:…[EOM]` framing and timestamps every frame.

- **The gate works** — shown on macOS, where a backgrounded app keeps running so a silence is attributable to the gate and nothing else: 12s cadence while focused, **84s of complete silence** at `appInBackground == true`, 12s again on refocus, no disconnect.
- **Resume is clean** — shown on an iPhone 16 Pro, driving the lifecycle with `devicectl`: reconnect-on-resume opens a new socket, state re-syncs, 12s cadence returns, no spurious `serverUnresponsive`.

One caveat worth stating: the iPhone silence is *not* evidence for the gate. iOS suspends the process when backgrounded, so those timers would not have fired either way — an unmodified build produces the same silence, which I checked. On iOS the gate's value is the inactive-but-not-suspended states (Control Center, notification banner, app switcher), plus foregrounded-idle cases on Android and desktop.

## Also fixed: a pre-existing double ping chain

Found while running the above. On resume the old socket is gone and reconnect-on-resume opens a new one, but the previous connection's pending ping `Future.delayed` thaws and latches onto the replacement — two chains on one socket, 0.48s apart, forever. They also race on `_serverResponsive`: one clears it, the other reads it cleared and force-disconnects a healthy connection.

`_pinging` cannot express this, because `_cleanup()` legitimately clears it when the old socket closes. A generation counter, bumped whenever a connection starts or ends and captured at schedule time, is decidable regardless of how thaw and reconnect interleave.

**Pre-existing, not caused by the gating** — verified by rebuilding with the two `appInBackground` checks removed and re-running the identical cycle, where it reproduces. Fixed here because it lives in the function this PR already touches.

Related and unchanged: the server's inbound `ping` → `pong` reply in `game_server.dart` is not gated, so a merely-unfocused desktop host still answers a client's keepalive. That matters because `AppLifecycleState.inactive` fires on plain window focus loss on desktop.

## Testing

New case in `test/services/client_test.dart` — fails without the generation fix (client disconnected 20s after a reconnect that should have succeeded), passes with it. Adds `fake_async` as a dev dependency. `flutter test`: 1524 pass / 1 skip / 2 fail, the 2 pre-existing on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZjzqhboES7T39Lu56zJkK


