### PR TITLE
Fix the two main menu tests that have been failing on main since #320

### DIFF
--- a/frosthaven_assistant/test/Layout/menus/main_menu_test.dart
+++ b/frosthaven_assistant/test/Layout/menus/main_menu_test.dart
@@ -113,6 +113,8 @@ void main() {
     ) async {
       await pumpMenu(tester);
       await tester.scrollUntilVisible(find.text('Add Monsters'), 100);
+      await tester.ensureVisible(find.text('Add Monsters'));
+      await tester.pump();
       await tester.tap(find.text('Add Monsters'));
       final originalOnError = FlutterError.onError;
       FlutterError.onError = ignoreOverflowErrors;
@@ -127,6 +129,8 @@ void main() {
     ) async {
       await pumpMenu(tester);
       await tester.scrollUntilVisible(find.text('Set Level'), 100);
+      await tester.ensureVisible(find.text('Set Level'));
+      await tester.pump();
       await tester.tap(find.text('Set Level'));
       final originalOnError = FlutterError.onError;
       FlutterError.onError = ignoreOverflowErrors;


### PR DESCRIPTION
> **PR 1 of 5 in a stack.** Merge in this order:
>
> **#328** ← *this PR* → **#324** → **#326** → **#327** → **#325**
>
> #328 is unrelated to the rest — it fixes two tests that have been failing on `main` since #320 merged, which turn every open PR's CI red. Everything below is stacked on it so that CI is meaningful.
>
> Nothing sits above this one — it is a single commit, and the smallest of the six.
>
> See also #329, an optional follow-up that hardens the rest of that test file.

`main` has been red since #320 merged. Two tests in `main_menu_test.dart` fail — "tapping Add Monsters opens AddMonsterMenu" and "tapping Set Level opens SetLevelMenu" — so every open PR inherits a failing `build` check.

Last green run was `8aded463`; the very next, `c8d25dde` (the #320 merge), is red. `45a5d94f` in that range adds one `ListTile` to `main_menu.dart`, which shifts every row below it down. **The menu change is fine — the tests were already fragile and this tipped them over.**

## Why they fail

`scrollUntilVisible` delegates to `dragUntilVisible`, whose loop stops when the target **exists in the widget tree**, not when it is visible:

```dart
while (maxIteration > 0 && finder.evaluate().isEmpty) { … }
await gesture?.up();
await Scrollable.ensureVisible(element(finder));   // no pump after this
```

A `ListView` instantiates children within the viewport **plus `cacheExtent`** (250px by default), so the drag halts while the row is still below `y=600`. The corrective `Scrollable.ensureVisible` then issues a `jumpTo`, which marks the viewport for layout but does not run it — and there is no `pump()` afterwards. `tap()` reads a stale transform and computes `Offset(396.0, 605.0)` / `Offset(396.0, 613.0)`, outside `Size(800.0, 600.0)`.

Flutter only *warns* on a missed tap, so `onTap` silently never fires and the `findsOneWidget` assertion is what actually throws — which is why the failure reads as "the menu didn't open" rather than "the tap missed".

## The fix

An `ensureVisible` + `pump()` between the scroll and the tap. The `pump()` is the load-bearing half: it flushes the pending `jumpTo` layout.

This is the same pattern already used a few tests down, in "tapping Loot Deck Menu opens LootCardsMenu" — that one evidently hit this before and was patched in place.

Four added lines, one test file, no `lib/` changes. Both tiles are byte-identical in shape to the passing Add Character / Remove Monsters tiles, and `add_monster_menu_test.dart` and `set_level_menu_test.dart` both pass on their own, so there is no product bug here.

## Note

Five other tests in this file scroll-then-tap without the `ensureVisible`/`pump` pair and pass only because their 100px drag increments happen to leave the target inside the viewport. They are one layout change away from exactly this. I've kept that out of this PR to keep it trivially reviewable, since `main` is red right now — happy to open the hardening separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZjzqhboES7T39Lu56zJkK

