### PR TITLE
Harden the rest of the main menu tests against the same scroll bug

### DIFF
--- a/frosthaven_assistant/test/Layout/menus/main_menu_test.dart
+++ b/frosthaven_assistant/test/Layout/menus/main_menu_test.dart
@@ -64,6 +64,28 @@ void main() {
     FlutterError.onError = originalOnError;
   }
 
+  /// Brings [target] into view and taps it.
+  ///
+  /// `scrollUntilVisible` on its own is not enough. Its drag loop stops as soon
+  /// as the target is *instantiated*, and a ListView instantiates anything
+  /// within `cacheExtent` (250px) of the viewport — so the row can still be
+  /// off-screen when the loop exits. It then calls `Scrollable.ensureVisible`,
+  /// which issues a `jumpTo` that marks the viewport for layout but does not
+  /// run it. Without a pump, `tap` reads a stale transform, computes an offset
+  /// outside the surface, and *silently misses* — Flutter only warns. The test
+  /// then fails on whatever it asserted next, which points nowhere near the
+  /// real cause.
+  ///
+  /// Scrolling unconditionally is deliberate: whether a given row happens to
+  /// start on-screen depends on how many items sit above it, which changes
+  /// every time a menu entry is added.
+  Future<void> scrollAndTap(WidgetTester tester, Finder target) async {
+    await tester.scrollUntilVisible(target, 100);
+    await tester.ensureVisible(target);
+    await tester.pump();
+    await tester.tap(target);
+  }
+
   group('MainMenu', () {
     testWidgets('renders Undo and Redo buttons', (WidgetTester tester) async {
       await pumpMenu(tester);
@@ -92,7 +114,7 @@ void main() {
       WidgetTester tester,
     ) async {
       await pumpMenu(tester);
-      await tester.tap(find.text('Set Scenario'));
+      await scrollAndTap(tester, find.text('Set Scenario'));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
       expect(find.byType(SelectScenarioMenu), findsOneWidget);
@@ -102,7 +124,7 @@ void main() {
       WidgetTester tester,
     ) async {
       await pumpMenu(tester);
-      await tester.tap(find.text('Add Character'));
+      await scrollAndTap(tester, find.text('Add Character'));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
       expect(find.byType(AddCharacterMenu), findsOneWidget);
@@ -112,10 +134,7 @@ void main() {
       WidgetTester tester,
     ) async {
       await pumpMenu(tester);
-      await tester.scrollUntilVisible(find.text('Add Monsters'), 100);
-      await tester.ensureVisible(find.text('Add Monsters'));
-      await tester.pump();
-      await tester.tap(find.text('Add Monsters'));
+      await scrollAndTap(tester, find.text('Add Monsters'));
       final originalOnError = FlutterError.onError;
       FlutterError.onError = ignoreOverflowErrors;
       await tester.pump();
@@ -128,10 +147,7 @@ void main() {
       WidgetTester tester,
     ) async {
       await pumpMenu(tester);
-      await tester.scrollUntilVisible(find.text('Set Level'), 100);
-      await tester.ensureVisible(find.text('Set Level'));
-      await tester.pump();
-      await tester.tap(find.text('Set Level'));
+      await scrollAndTap(tester, find.text('Set Level'));
       final originalOnError = FlutterError.onError;
       FlutterError.onError = ignoreOverflowErrors;
       await tester.pump();
@@ -151,7 +167,7 @@ void main() {
       final indexBefore = gameState.commandIndex.value;
 
       await pumpMenu(tester);
-      await tester.tap(find.textContaining('Undo'));
+      await scrollAndTap(tester, find.textContaining('Undo'));
       await tester.pump();
 
       expect(gameState.commandIndex.value, indexBefore - 1);
@@ -169,7 +185,7 @@ void main() {
       final indexBefore = gameState.commandIndex.value;
 
       await pumpMenu(tester);
-      await tester.tap(find.textContaining('Redo'));
+      await scrollAndTap(tester, find.textContaining('Redo'));
       await tester.pump();
 
       expect(gameState.commandIndex.value, indexBefore + 1);
@@ -187,8 +203,7 @@ void main() {
       ).execute();
 
       await pumpMenu(tester);
-      await tester.scrollUntilVisible(find.text('Add Section'), 100);
-      await tester.tap(find.text('Add Section'));
+      await scrollAndTap(tester, find.text('Add Section'));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
       expect(find.byType(AddSectionMenu), findsOneWidget);
@@ -198,8 +213,7 @@ void main() {
       WidgetTester tester,
     ) async {
       await pumpMenu(tester);
-      await tester.scrollUntilVisible(find.text('Remove Characters'), 100);
-      await tester.tap(find.text('Remove Characters'));
+      await scrollAndTap(tester, find.text('Remove Characters'));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
       expect(find.byType(RemoveCharacterMenu), findsOneWidget);
@@ -209,8 +223,7 @@ void main() {
       WidgetTester tester,
     ) async {
       await pumpMenu(tester);
-      await tester.scrollUntilVisible(find.text('Remove Monsters'), 100);
-      await tester.tap(find.text('Remove Monsters'));
+      await scrollAndTap(tester, find.text('Remove Monsters'));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
       expect(find.byType(RemoveMonsterMenu), findsOneWidget);
@@ -228,10 +241,7 @@ void main() {
       ).execute();
 
       await pumpMenu(tester);
-      await tester.scrollUntilVisible(find.text('Loot Deck Menu'), 100);
-      await tester.ensureVisible(find.text('Loot Deck Menu'));
-      await tester.pump();
-      await tester.tap(find.text('Loot Deck Menu'));
+      await scrollAndTap(tester, find.text('Loot Deck Menu'));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
       expect(find.byType(LootCardsMenu), findsOneWidget);
@@ -241,8 +251,7 @@ void main() {
       WidgetTester tester,
     ) async {
       await pumpMenu(tester);
-      await tester.scrollUntilVisible(find.text('Settings'), 100);
-      await tester.tap(find.text('Settings'));
+      await scrollAndTap(tester, find.text('Settings'));
       final originalOnError = FlutterError.onError;
       FlutterError.onError = ignoreOverflowErrors;
       await tester.pump();
@@ -282,11 +291,10 @@ void main() {
         }
 
         await pumpMenu(tester);
-        await tester.scrollUntilVisible(
+        await scrollAndTap(
+          tester,
           find.text('Show Ally Attack Modifier Deck'),
-          100,
         );
-        await tester.tap(find.text('Show Ally Attack Modifier Deck'));
         await tester.pump();
 
         expect(gameState.showAllyDeck.value, true);
@@ -341,11 +349,10 @@ void main() {
       }
 
       await pumpMenu(tester);
-      await tester.scrollUntilVisible(
+      await scrollAndTap(
+        tester,
         find.text('Hide Ally Attack Modifier Deck'),
-        100,
       );
-      await tester.tap(find.text('Hide Ally Attack Modifier Deck'));
       await tester.pump();
 
       expect(gameState.showAllyDeck.value, false);

--- a/frosthaven_assistant/test/Layout/menus/main_menu_test.dart
+++ b/frosthaven_assistant/test/Layout/menus/main_menu_test.dart
@@ -113,6 +113,8 @@ void main() {
     ) async {
       await pumpMenu(tester);
       await tester.scrollUntilVisible(find.text('Add Monsters'), 100);
+      await tester.ensureVisible(find.text('Add Monsters'));
+      await tester.pump();
       await tester.tap(find.text('Add Monsters'));
       final originalOnError = FlutterError.onError;
       FlutterError.onError = ignoreOverflowErrors;
@@ -127,6 +129,8 @@ void main() {
     ) async {
       await pumpMenu(tester);
       await tester.scrollUntilVisible(find.text('Set Level'), 100);
+      await tester.ensureVisible(find.text('Set Level'));
+      await tester.pump();
       await tester.tap(find.text('Set Level'));
       final originalOnError = FlutterError.onError;
       FlutterError.onError = ignoreOverflowErrors;


### PR DESCRIPTION
> **Optional side branch off #328** — not part of the main stack, nothing depends on it.
> Merge #328 first; this only makes sense on top of it.
>
> A fork PR can only target `main`, so this diff also contains #328's commit. **Review the 2nd commit only.**

#328 fixes the two tests that are currently failing on `main`. They were not special — they were just the first to cross the line.

In `main_menu_test.dart`, five other tests scroll-then-tap without the `ensureVisible`/`pump` pair and pass only because their 100px drag increments happen to leave the target inside the viewport. Two more tap without scrolling at all, because their rows currently start on-screen. Every one of those properties depends on how many menu entries sit above the row — which changes whenever a menu entry is added, which is exactly what just broke `main`.

This routes all thirteen tap sites through one helper:

```dart
Future<void> scrollAndTap(WidgetTester tester, Finder target) async {
  await tester.scrollUntilVisible(target, 100);
  await tester.ensureVisible(target);
  await tester.pump();
  await tester.tap(target);
}
```

Scrolling unconditionally is deliberate — "this row happens to be visible today" is not a property worth depending on.

## Measured, not assumed

Shrinking the test surface from 800x600 to 800x480 breaks **three more tests** on top of #328: Settings, Show Ally Attack Modifier Deck, and Add Character — the last of which does not scroll today at all. With this commit, the same 800x480 run passes all 21.

(That viewport change was a temporary probe to demonstrate the fragility; it is not part of the diff.)

## Testing

`flutter test`: **1517 pass / 1 skip / 0 fail**. `flutter analyze`: no new issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZjzqhboES7T39Lu56zJkK

