### PR TITLE
Animate each modifier card draw exactly once

### DIFF
--- a/frosthaven_assistant/lib/Layout/ModifierDeckWidget/modifier_deck_widget.dart
+++ b/frosthaven_assistant/lib/Layout/ModifierDeckWidget/modifier_deck_widget.dart
@@ -56,6 +56,23 @@ class ModifierDeckWidgetState extends State<ModifierDeckWidget> {
       );
   bool _animationsEnabled = false;
 
+  /// Enables the draw animation for a pending draw event unless it has already
+  /// been animated. Used for remote (client) draws, where no local tap fires
+  /// and the draw is detected from the view model.
+  void _maybeEnableDrawAnimation() {
+    if (_animationsEnabled || !_vm.initAnimationEnabled()) return;
+    _animationsEnabled = true;
+    _vm.markDrawAnimated();
+  }
+
+  /// Draws a card from a local tap and animates it, marking the resulting event
+  /// as animated so the same draw is not replayed on a later rebuild.
+  void _drawAndAnimate() {
+    _vm.drawCard();
+    _animationsEnabled = true;
+    _vm.markDrawAnimated();
+  }
+
   @override
   void didUpdateWidget(ModifierDeckWidget oldWidget) {
     super.didUpdateWidget(oldWidget);
@@ -146,9 +163,7 @@ class ModifierDeckWidgetState extends State<ModifierDeckWidget> {
                 listenable: Listenable.merge(
                     [_vm.lastEvent, _vm.cardCount, _vm.revealedCount]),
                 builder: (context, child) {
-                  if (!_animationsEnabled) {
-                    _animationsEnabled = _vm.initAnimationEnabled();
-                  }
+                  _maybeEnableDrawAnimation();
 
                   final textStyle = TextStyle(
                       fontSize: kDeckFontSize * userScalingBars,
@@ -185,10 +200,7 @@ class ModifierDeckWidgetState extends State<ModifierDeckWidget> {
                     children: [
                       InkWell(
                           onTap: () {
-                            setState(() {
-                              _animationsEnabled = true;
-                              _vm.drawCard();
-                            });
+                            setState(_drawAndAnimate);
                           },
                           child: Stack(children: [
                             deck.drawPileIsNotEmpty
@@ -205,10 +217,7 @@ class ModifierDeckWidgetState extends State<ModifierDeckWidget> {
                                                 focusColor:
                                                     const Color(0x44000000),
                                                 onTap: () {
-                                                  setState(() {
-                                                    _animationsEnabled = true;
-                                                    _vm.drawCard();
-                                                  });
+                                                  setState(_drawAndAnimate);
                                                 })))
                                   ])
                                 : Stack(children: [
@@ -229,10 +238,7 @@ class ModifierDeckWidgetState extends State<ModifierDeckWidget> {
                                               focusColor:
                                                   const Color(0x44000000),
                                               onTap: () {
-                                                setState(() {
-                                                  _animationsEnabled = true;
-                                                  _vm.drawCard();
-                                                });
+                                                setState(_drawAndAnimate);
                                               },
                                               child: Center(
                                                   child: Text(

--- a/frosthaven_assistant/lib/Layout/view_models/modifier_deck_view_model.dart
+++ b/frosthaven_assistant/lib/Layout/view_models/modifier_deck_view_model.dart
@@ -50,9 +50,34 @@ class ModifierDeckViewModel {
 
   String? get currentCharacterName => currentCharacter?.characterClass.name;
 
-  bool initAnimationEnabled() {
+  // The draw event we have already animated. [_gameState.lastEvent] keeps the
+  // last ModifierCardDrawnEvent set until the next command replaces it, so a
+  // rebuild that is not itself a new draw (scaling the bars, revealing, opening
+  // the menu) would otherwise re-trigger the animation and replay it. Tracking
+  // the event by identity lets us animate each draw exactly once.
+  Object? _lastAnimatedEvent;
+
+  /// The pending draw event for this deck that has not yet been consumed, or
+  /// null if the last event is not a draw for this deck.
+  GameEvent? get _pendingDrawEvent {
     final event = _gameState.lastEvent.value;
-    return event is ModifierCardDrawnEvent && event.deckName == name;
+    if (event is ModifierCardDrawnEvent && event.deckName == name) return event;
+    return null;
+  }
+
+  /// Whether a draw animation should start now: there is a pending draw for
+  /// this deck and we have not already animated it. Pure — call
+  /// [markDrawAnimated] once the animation has been started.
+  bool initAnimationEnabled() {
+    final event = _pendingDrawEvent;
+    return event != null && !identical(event, _lastAnimatedEvent);
+  }
+
+  /// Records the current pending draw as animated so it is not replayed on a
+  /// later rebuild. Also used for local taps, where the widget enables the
+  /// animation directly without going through [initAnimationEnabled].
+  void markDrawAnimated() {
+    _lastAnimatedEvent = _gameState.lastEvent.value;
   }
 
   void drawCard() {

--- a/frosthaven_assistant/test/Layout/modifier_deck_widget_test.dart
+++ b/frosthaven_assistant/test/Layout/modifier_deck_widget_test.dart
@@ -6,8 +6,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:frosthaven_assistant/Layout/ModifierCardWidget/modifier_card_front.dart';
 import 'package:frosthaven_assistant/Layout/ModifierCardWidget/modifier_card_rear.dart';
 import 'package:frosthaven_assistant/Layout/ModifierDeckWidget/modifier_deck_widget.dart';
+import 'package:frosthaven_assistant/Layout/ModifierDeckWidget/modifier_slide_animation_widget.dart';
 import 'package:frosthaven_assistant/Layout/menus/ModifierDeckMenu/modifier_deck_menu.dart';
 import 'package:frosthaven_assistant/Layout/menus/modifier_card_zoom.dart';
+import 'package:frosthaven_assistant/Resource/settings.dart';
 import 'package:frosthaven_assistant/Resource/commands/amd_reveal_command.dart';
 import 'package:frosthaven_assistant/Resource/commands/add_character_command.dart';
 import 'package:frosthaven_assistant/Resource/commands/draw_modifier_card_command.dart';
@@ -173,6 +175,47 @@ void main() {
       await pumpWidget(tester, monsterDeckName);
       expect(find.byType(Row), findsAtLeast(1));
     });
+
+    testWidgets(
+      'does not replay the draw animation on an unrelated (scaling) rebuild',
+      (WidgetTester tester) async {
+        final gameState = getIt<GameState>();
+        final settings = getIt<Settings>();
+        final scalingBefore = settings.userScalingBars.value;
+
+        // Two draws so the discard pile has >1 card, which renders the slide
+        // animation whenever animations are enabled — our observable.
+        gameState.action(
+          DrawModifierCardCommand(monsterDeckName, gameState: gameState),
+        );
+        gameState.action(
+          DrawModifierCardCommand(monsterDeckName, gameState: gameState),
+        );
+
+        final originalOnError = FlutterError.onError;
+        addTearDown(() => FlutterError.onError = originalOnError);
+        FlutterError.onError = ignoreOverflowErrors;
+
+        await pumpWidget(tester, monsterDeckName);
+        // The pending draw animates on first build.
+        expect(find.byType(ModifierSlideAnimationWidget), findsOneWidget);
+
+        // Let the 1200ms animation finish (onComplete clears the flag).
+        await tester.pump(const Duration(milliseconds: 1300));
+
+        // Drag the scaling slider: a rebuild that is NOT a new draw. The draw
+        // event still lingers in lastEvent, so the pre-fix code replayed here.
+        settings.userScalingBars.value = scalingBefore + 0.1;
+        await tester.pump();
+
+        expect(find.byType(ModifierSlideAnimationWidget), findsNothing);
+
+        FlutterError.onError = originalOnError;
+        settings.userScalingBars.value = scalingBefore;
+        gameState.undo();
+        gameState.undo();
+      },
+    );
 
     testWidgets('card count text updates after drawing a card', (
       WidgetTester tester,

--- a/frosthaven_assistant/test/Layout/view_models/deck_view_models_test.dart
+++ b/frosthaven_assistant/test/Layout/view_models/deck_view_models_test.dart
@@ -204,6 +204,33 @@ void main() {
       expect(vm.initAnimationEnabled(), isFalse);
       gs.undo();
     });
+
+    test('false once the drawn card has been marked animated', () {
+      // The draw event lingers in lastEvent after the animation runs, so an
+      // unrelated rebuild must not replay it. markDrawAnimated consumes it.
+      final gs = getIt<GameState>();
+      gs.action(DrawModifierCardCommand('Monster', gameState: gs));
+      final vm = makeModifierVm('Monster');
+      expect(vm.initAnimationEnabled(), isTrue);
+      vm.markDrawAnimated();
+      expect(vm.initAnimationEnabled(), isFalse);
+      gs.undo();
+    });
+
+    test('true again for a second draw after the first was animated', () {
+      // Reuse one view model across both draws — the dedup state lives there.
+      final gs = getIt<GameState>();
+      final vm = makeModifierVm('Monster');
+      gs.action(DrawModifierCardCommand('Monster', gameState: gs));
+      expect(vm.initAnimationEnabled(), isTrue);
+      vm.markDrawAnimated();
+      expect(vm.initAnimationEnabled(), isFalse);
+      // A fresh draw is a new event, so it animates again.
+      gs.action(DrawModifierCardCommand('Monster', gameState: gs));
+      expect(vm.initAnimationEnabled(), isTrue);
+      gs.undo();
+      gs.undo();
+    });
   });
 
   group('ModifierDeckViewModel notifiers', () {


### PR DESCRIPTION
### Problem
The modifier-deck draw animation replays whenever an **unrelated** rebuild happens after a draw — dragging the scaling bars, revealing a card, or opening the deck menu. `ModifierDeckViewModel.initAnimationEnabled()` returns `true` for as long as the last game event is the draw, and that event lingers in `lastEvent` until the next command replaces it, so any rebuild in between re-enables the animation.

### Fix
Track the draw event that has already been animated (by identity) in the view model, and only animate a draw we haven't seen yet. `markDrawAnimated()` consumes the current draw; the widget calls it both when it detects a remote (client) draw and when the user taps to draw locally, so neither path replays. `initAnimationEnabled()` stays a pure predicate.

### Tests
- View-model unit tests: the drawn card stops animating once marked, and a second draw animates again.
- Widget test that fails if a scaling-slider rebuild replays the animation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VhUaTgGMN7BCUCXgKckdrV